### PR TITLE
OS Agnostic packaging with PyInstaller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    name: Syntax check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Compile all Python sources
+        run: python -m compileall -q core ui main.py build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,9 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact: splatt2-linux-x64
-          - os: macos-latest
+          - os: macos-26
             artifact: splatt2-macos-arm64
-          - os: macos-13
+          - os: macos-26-intel
             artifact: splatt2-macos-x64
           - os: windows-latest
             artifact: splatt2-windows-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      publish_release:
+        description: "Create a GitHub Release and attach the built zips"
+        type: boolean
+        default: false
+      release_tag:
+        description: "Tag for the release when publish_release is true (e.g. v1.2.0-rc1)"
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: splatt2-linux-x64
+          - os: macos-latest
+            artifact: splatt2-macos-arm64
+          - os: macos-13
+            artifact: splatt2-macos-x64
+          - os: windows-latest
+            artifact: splatt2-windows-x64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-build.txt
+
+      - name: Install Linux runtime deps
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgl1 libglib2.0-0 \
+            libportaudio2 \
+            python3-tk
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-build.txt
+
+      - name: Build with PyInstaller
+        run: python build/build.py --clean
+
+      - name: Package artifact (zip)
+        if: runner.os != 'macOS'
+        shell: bash
+        run: |
+          cd dist
+          for d in splatt2-*/; do
+            d="${d%/}"
+            python -c "import shutil; shutil.make_archive('${d}', 'zip', '.', '${d}')"
+          done
+          ls -la
+
+      - name: Package artifact (zip, macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          cd dist
+          for d in splatt2-*/; do
+            d="${d%/}"
+            ditto -c -k --sequesterRsrc --keepParent "${d}" "${d}.zip"
+          done
+          ls -la
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist/*.zip
+          if-no-files-found: error
+          retention-days: 30
+
+  release:
+    name: Publish GitHub Release
+    needs: build
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.publish_release == true)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate manual-dispatch inputs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ -z "${{ inputs.release_tag }}" ]; then
+            echo "::error::publish_release was ticked but release_tag is empty"
+            exit 1
+          fi
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: >-
+            ${{ github.event_name == 'workflow_dispatch'
+                && inputs.release_tag
+                || github.ref_name }}
+          files: artifacts/**/*.zip
+          generate_release_notes: true
+          prerelease: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ desktop.ini
 
 # Generated images (from marker sheet dialog)
 aruco_sheet*.png
+
+# Build artifacts
+dist/
+build/_pyinstaller_work/
+build/icons/

--- a/README.md
+++ b/README.md
@@ -34,22 +34,48 @@ Changing the pellet calibre in Settings instantly shifts all scoring bands — o
 
 ## Requirements
 
-- Windows 10 or 11 (64-bit)
-- **Python 3.9+** — download from https://python.org — tick **"Add Python to PATH"** during installation
+- Windows 10/11, macOS 12+, or a recent 64-bit Linux desktop
 - A webcam (USB recommended for barrel-mounting; built-in works for testing)
 - A microphone (built-in laptop mic is fine for dry-fire; closer to the action is better for live fire)
+- **Python 3.9+** is only needed when running from source — pre-built binaries bundle their own runtime
 
 ---
 
-## Quick Start
+## Quick Start (pre-built binary)
 
-1. Install Python from https://python.org (tick "Add Python to PATH")
-2. Download or clone this repository
-3. Double-click **`RUN.bat`**
+Download the latest release for your OS from the [Releases page](../../releases/latest):
 
-That's it. `RUN.bat` automatically installs all Python dependencies (`numpy`, `opencv`, `sounddevice`, `Pillow`, `scipy`) the first time it runs, then launches Splatt2. On subsequent runs it checks for updates to dependencies and starts immediately.
+- `splatt2-windows-x64.zip`
+- `splatt2-macos-arm64.zip` (Apple Silicon) or `splatt2-macos-x64.zip` (Intel)
+- `splatt2-linux-x64.zip`
 
-> **To share with someone else:** give them the folder and tell them to install Python and double-click `RUN.bat`. No compilation, no installers, no antivirus drama.
+Unzip anywhere and launch:
+
+- **Windows** — run `splatt2.exe`
+- **macOS** — open `Splatt2.app` (right-click → Open the first time so Gatekeeper allows the unsigned bundle)
+- **Linux** — `chmod +x splatt2 && ./splatt2`
+
+User config and shooting sessions are saved to your OS-native app data folder:
+
+| OS      | Location                                               |
+| ------- | ------------------------------------------------------ |
+| Windows | `%APPDATA%\Splatt2`                                    |
+| macOS   | `~/Library/Application Support/Splatt2`                |
+| Linux   | `~/.local/share/Splatt2` (or `$XDG_DATA_HOME/Splatt2`) |
+
+Override with `SPLATT2_USER_DIR=/some/path` for testing or portable installs.
+
+---
+
+## Quick Start (run from source)
+
+1. Install Python 3.9+ from https://python.org (Windows: tick **"Add Python to PATH"**)
+2. Clone or download this repository
+3. Launch:
+   - **Windows** — double-click `RUN.bat`
+   - **macOS / Linux** — `pip install -r requirements.txt && python main.py`
+
+`RUN.bat` installs the Python deps (`numpy`, `opencv`, `sounddevice`, `Pillow`, `scipy`) on first run, then starts the app.
 
 ---
 
@@ -252,9 +278,11 @@ Open **Print Marker Sheet → Target Creator** tab to create or edit targets wit
 
 ## Session Files
 
-Sessions are saved in the `sessions/` folder (next to the app, or as configured in Settings). Each day of shooting creates a subfolder named `YYYY-MM-DD/`. Within each day, each series is a separate file named `HH-MM-SS_name_series1.csv`.
+Series recordings are saved to the `sessions/` folder inside your user data directory (see *Quick Start (pre-built binary)* for the per-OS path), or in a custom location configured in Settings → Session. Each day of shooting creates a subfolder named `YYYY-MM-DD/`. Within each day, each series is a separate file named `HH-MM-SS_name_series1.csv`.
 
 Each `.csv` has a companion `.json` file with full trace data for the Series Review window.
+
+> Splatt2 versions before this one stored the config and `sessions/` folder next to `main.py`. On first launch of a newer build, the config is migrated into the per-user app data directory automatically. The original is left in place.
 
 ---
 
@@ -313,13 +341,19 @@ Each `.csv` has a companion `.json` file with full trace data for the Series Rev
 ```
 splatt2/
 ├── main.py                  Entry point with crash logging
-├── RUN.bat                  Install dependencies & launch (double-click to run)
-├── requirements.txt         Python dependencies
-├── targets/                 Target definition CSV files — add your own here
+├── RUN.bat                  Install dependencies & launch (Windows dev flow)
+├── requirements.txt         Runtime Python dependencies
+├── requirements-build.txt   Build-time dependencies (PyInstaller)
+├── targets/                 Bundled target definition CSVs (read-only seeds)
 │   ├── 10m_air_rifle.csv
 │   ├── 10m_air_pistol.csv
 │   └── 6yd_air_rifle.csv
+├── build/
+│   ├── splatt2.spec         PyInstaller spec
+│   ├── build.py             Cross-platform build script
+│   └── README.md            Build instructions
 ├── core/
+│   ├── paths.py             Cross-platform resource and user-data paths
 │   ├── config.py            Settings management and target CSV loader
 │   ├── tracker.py           ArUco detection, homography, scoring geometry
 │   ├── audio.py             Shot sound detection (transient detection)
@@ -327,9 +361,38 @@ splatt2/
 │   ├── target_renderer.py   OpenCV target canvas drawing
 │   ├── marker_sheet.py      Printable ArUco sheet generator
 │   └── smoother.py          Aim-point smoothing (EMA / Savitzky-Golay)
-└── ui/
-    └── app.py               Main tkinter UI
+├── ui/
+│   └── app.py               Main tkinter UI
+└── .github/workflows/
+    ├── ci.yml               Syntax check on push and PR
+    └── release.yml          Cross-platform PyInstaller builds on tag
 ```
+
+---
+
+## Building from Source
+
+To produce a standalone bundle for your platform:
+
+```
+pip install -r requirements.txt -r requirements-build.txt
+python build/build.py --clean
+```
+
+Output lands in `dist/splatt2-<os>-<arch>/`. See [`build/README.md`](build/README.md) for per-OS notes.
+
+Pre-built binaries are produced automatically by GitHub Actions on every tag — see [`.github/workflows/release.yml`](.github/workflows/release.yml).
+
+### On-demand builds via GitHub Actions
+
+You can trigger the release workflow manually without pushing a tag:
+
+1. Go to **Actions → Release → Run workflow**
+2. Pick the branch
+3. Leave **Create a GitHub Release** unticked to just produce downloadable artifacts attached to the workflow run (kept for 30 days)
+4. Tick it and supply a tag (e.g. `v1.2.0-rc1`) to publish a pre-release with the zips attached
+
+Manual-dispatch releases are flagged as pre-releases so they don't override the latest stable.
 
 ---
 

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,52 @@
+# Build
+
+Cross-platform PyInstaller build of Splatt2 for the host OS.
+
+## Prerequisites
+
+```
+pip install -r requirements.txt -r requirements-build.txt
+```
+
+Platform notes:
+
+- **Linux** — install system tk and PortAudio runtime libs:
+  `sudo apt-get install python3-tk libportaudio2`
+- **macOS** — Xcode Command Line Tools (for codesigning).
+- **Windows** — no extras; PyInstaller wheels include the bootloader.
+
+## Build
+
+```
+python build/build.py            # build for the current OS
+python build/build.py --clean    # delete dist/ and build cache first
+```
+
+Output:
+
+```
+dist/splatt2-<os>-<arch>/
+```
+
+On macOS the directory contains `Splatt2.app` (the launchable bundle)
+plus the underlying onedir layout used by the bootloader. On Windows
+and Linux the binary is `splatt2(.exe)` alongside `_internal/`.
+
+## Files
+
+- `build/splatt2.spec` — PyInstaller spec, single source of truth for
+  what gets bundled (data files, hidden imports, per-OS branches).
+- `build/build.py` — wrapper around `pyinstaller` that handles cleanup
+  and renames the output to a stable per-platform directory name.
+
+## Icons
+
+Drop platform icons into `build/icons/`:
+
+```
+build/icons/splatt2.ico    Windows
+build/icons/splatt2.icns   macOS
+build/icons/splatt2.png    Linux
+```
+
+If absent the build still succeeds with PyInstaller's defaults.

--- a/build/build.py
+++ b/build/build.py
@@ -1,0 +1,100 @@
+"""
+Cross-platform PyInstaller build entry point for Splatt2.
+
+Usage:
+    python build/build.py            # build for the current OS
+    python build/build.py --clean    # delete dist/ and build cache first
+
+Output:
+    dist/splatt2-<os>-<arch>/        # onedir bundle, ready to zip
+
+The spec file (build/splatt2.spec) holds the actual build description.
+This script handles cleanup, output renaming, and tagging by OS/arch so
+CI and local builds produce identically-named artifacts.
+"""
+
+import argparse
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SPEC = ROOT / "build" / "splatt2.spec"
+DIST = ROOT / "dist"
+WORK = ROOT / "build" / "_pyinstaller_work"
+
+
+def _os_tag() -> str:
+    if sys.platform.startswith("win"):
+        return "windows"
+    if sys.platform == "darwin":
+        return "macos"
+    return "linux"
+
+
+def _arch_tag() -> str:
+    m = platform.machine().lower()
+    return {
+        "amd64": "x64", "x86_64": "x64",
+        "arm64": "arm64", "aarch64": "arm64",
+    }.get(m, m or "unknown")
+
+
+def _rename_output(target_name: str) -> Path:
+    """Move PyInstaller's per-OS output into dist/splatt2-<os>-<arch>/.
+
+    On macOS the BUNDLE step produces ``dist/Splatt2.app`` — the artifact
+    end users actually launch. It's moved inside the target folder so
+    every platform produces a single zippable directory.
+    """
+    src = DIST / "splatt2"
+    dst = DIST / target_name
+    if dst.exists():
+        shutil.rmtree(dst)
+    if src.exists():
+        src.rename(dst)
+
+    if sys.platform == "darwin":
+        app = DIST / "Splatt2.app"
+        if app.exists():
+            dst.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(app), str(dst / "Splatt2.app"))
+    return dst
+
+
+def _build(clean: bool) -> int:
+    if clean:
+        for p in (DIST, WORK):
+            if p.exists():
+                print(f"[build] Removing {p}")
+                shutil.rmtree(p)
+
+    cmd = [
+        sys.executable, "-m", "PyInstaller",
+        "--noconfirm",
+        f"--distpath={DIST}",
+        f"--workpath={WORK}",
+        str(SPEC),
+    ]
+    print("[build] " + " ".join(cmd))
+    rc = subprocess.call(cmd, cwd=ROOT)
+    if rc != 0:
+        return rc
+
+    target = f"splatt2-{_os_tag()}-{_arch_tag()}"
+    out = _rename_output(target)
+    print(f"[build] Output: {out}")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Build Splatt2 with PyInstaller")
+    p.add_argument("--clean", action="store_true",
+                   help="Delete dist/ and build cache before building")
+    return _build(p.parse_args().clean)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/build.py
+++ b/build/build.py
@@ -43,24 +43,29 @@ def _arch_tag() -> str:
 
 
 def _rename_output(target_name: str) -> Path:
-    """Move PyInstaller's per-OS output into dist/splatt2-<os>-<arch>/.
+    """Stage the platform-specific output under dist/splatt2-<os>-<arch>/.
 
-    On macOS the BUNDLE step produces ``dist/Splatt2.app`` — the artifact
-    end users actually launch. It's moved inside the target folder so
-    every platform produces a single zippable directory.
+    On macOS the launchable artifact is ``dist/Splatt2.app`` produced by
+    the BUNDLE step; the loose COLLECT directory only duplicates what's
+    already inside the bundle, so it's dropped. On Windows and Linux
+    the COLLECT directory IS the artifact.
     """
     src = DIST / "splatt2"
     dst = DIST / target_name
     if dst.exists():
         shutil.rmtree(dst)
-    if src.exists():
-        src.rename(dst)
 
     if sys.platform == "darwin":
+        dst.mkdir(parents=True, exist_ok=True)
         app = DIST / "Splatt2.app"
         if app.exists():
-            dst.mkdir(parents=True, exist_ok=True)
             shutil.move(str(app), str(dst / "Splatt2.app"))
+        if src.exists():
+            shutil.rmtree(src)
+    else:
+        if src.exists():
+            src.rename(dst)
+
     return dst
 
 

--- a/build/splatt2.spec
+++ b/build/splatt2.spec
@@ -62,6 +62,7 @@ exe = EXE(
     console=False,
     disable_windowed_traceback=False,
     icon=icon_arg,
+    contents_directory=".",
 )
 
 coll = COLLECT(

--- a/build/splatt2.spec
+++ b/build/splatt2.spec
@@ -1,0 +1,89 @@
+# PyInstaller spec for Splatt2.
+#
+# Run via build/build.py rather than directly so the working dir, output
+# layout and platform tweaks are consistent.
+
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_all, collect_submodules
+
+ROOT = Path(SPECPATH).parent
+APP_NAME = "splatt2"
+ENTRY = str(ROOT / "main.py")
+
+datas = [(str(ROOT / "targets"), "targets")]
+binaries = []
+hiddenimports = [
+    # Pillow's tkinter integration is loaded dynamically.
+    "PIL._tkinter_finder",
+]
+
+# sounddevice ships its own PortAudio binary in _sounddevice_data/.
+sd_datas, sd_binaries, sd_hidden = collect_all("sounddevice")
+datas += sd_datas
+binaries += sd_binaries
+hiddenimports += sd_hidden
+
+# scipy uses lazy submodule imports that PyInstaller's tracer misses.
+hiddenimports += collect_submodules("scipy")
+
+
+a = Analysis(
+    [ENTRY],
+    pathex=[str(ROOT)],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+
+_icon_dir = ROOT / "build" / "icons"
+if sys.platform.startswith("win"):
+    _icon = _icon_dir / "splatt2.ico"
+elif sys.platform == "darwin":
+    _icon = _icon_dir / "splatt2.icns"
+else:
+    _icon = _icon_dir / "splatt2.png"
+icon_arg = str(_icon) if _icon.exists() else None
+
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name=APP_NAME,
+    console=False,
+    disable_windowed_traceback=False,
+    icon=icon_arg,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    name=APP_NAME,
+)
+
+if sys.platform == "darwin":
+    app = BUNDLE(
+        coll,
+        name="Splatt2.app",
+        bundle_identifier="com.splatt2.app",
+        icon=icon_arg,
+        info_plist={
+            "CFBundleName": "Splatt2",
+            "CFBundleDisplayName": "Splatt2",
+            "NSHighResolutionCapable": True,
+            "NSCameraUsageDescription":
+                "Splatt2 uses the camera to track the rifle's aim point.",
+            "NSMicrophoneUsageDescription":
+                "Splatt2 uses the microphone to detect the shot click.",
+        },
+    )

--- a/core/config.py
+++ b/core/config.py
@@ -243,7 +243,7 @@ DEFAULT_CONFIG = {
     "session_name":       "Session",
     "shooter_name":       "",
     "shots_per_series":   10,
-    "save_directory":     "",    # empty = sessions/ folder next to the app
+    "save_directory":     "",    # empty = sessions/ folder in user data dir
 }
 
 

--- a/core/config.py
+++ b/core/config.py
@@ -7,7 +7,7 @@ import json
 import os
 import shutil
 
-from core.paths import config_path, resource_path
+from core.paths import config_path, resource_path, user_targets_dir
 
 VERSION = "1.1.0"
 
@@ -38,8 +38,13 @@ _migrate_legacy_config()
 # Ring diameters are in mm (not radii). Innermost ring first.
 
 def _targets_dir() -> str:
-    """Path to the bundled targets/ folder."""
+    """Path to the bundled targets/ folder (read-only seeds)."""
     return str(resource_path("targets"))
+
+
+def _user_targets_dir() -> str:
+    """Path to the user-writable targets/ folder."""
+    return str(user_targets_dir())
 
 
 def _load_target_csv(path: str) -> dict:
@@ -143,19 +148,21 @@ def _load_target_csv(path: str) -> dict:
     }
 
 def _load_all_targets() -> dict:
-    """Load all .csv files from the targets/ folder. Returns {key: target_dict}."""
-    tdir = _targets_dir()
+    """Load targets from the bundled and user dirs.
+
+    User files override bundled files when keys collide, so a shooter
+    can tweak a built-in target without losing the original.
+    """
     targets = {}
-    if not os.path.isdir(tdir):
-        print(f"[Targets] Folder not found: {tdir}")
-        return targets
-    for fname in sorted(os.listdir(tdir)):
-        if not fname.lower().endswith(".csv"):
+    for tdir in (_targets_dir(), _user_targets_dir()):
+        if not os.path.isdir(tdir):
             continue
-        path = os.path.join(tdir, fname)
-        t = _load_target_csv(path)
-        if t:
-            targets[t["key"]] = t
+        for fname in sorted(os.listdir(tdir)):
+            if not fname.lower().endswith(".csv"):
+                continue
+            t = _load_target_csv(os.path.join(tdir, fname))
+            if t:
+                targets[t["key"]] = t
     return targets
 
 

--- a/core/config.py
+++ b/core/config.py
@@ -5,19 +5,31 @@ All user-configurable settings and target definitions.
 
 import json
 import os
+import shutil
 
-from core.paths import resource_path
+from core.paths import config_path, resource_path
 
 VERSION = "1.1.0"
 
-def _config_path() -> str:
-    """Config file lives in the project root (next to main.py)."""
-    import os
-    base = os.path.dirname(os.path.abspath(__file__))
-    base = os.path.dirname(base)  # up from core/ to project root
-    return os.path.join(base, "splatt2_config.json")
+CONFIG_FILE = str(config_path())
 
-CONFIG_FILE = _config_path()
+
+def _migrate_legacy_config() -> None:
+    """Copy a pre-1.2 config sitting next to main.py into the user dir."""
+    if os.path.exists(CONFIG_FILE):
+        return
+    legacy = os.path.join(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__))), "splatt2_config.json")
+    if os.path.isfile(legacy):
+        try:
+            os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
+            shutil.copy2(legacy, CONFIG_FILE)
+            print(f"[Config] Migrated legacy config -> {CONFIG_FILE}")
+        except OSError as e:
+            print(f"[Config] Could not migrate legacy config: {e}")
+
+
+_migrate_legacy_config()
 
 # ── Target definitions — loaded from targets/ folder ────────────────────────
 # Each .csv in the targets/ folder defines one target.
@@ -244,6 +256,7 @@ def load_config():
 
 def save_config(cfg: dict):
     try:
+        os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
         with open(CONFIG_FILE, "w") as f:
             json.dump(cfg, f, indent=2)
     except Exception as e:

--- a/core/config.py
+++ b/core/config.py
@@ -6,6 +6,8 @@ All user-configurable settings and target definitions.
 import json
 import os
 
+from core.paths import resource_path
+
 VERSION = "1.1.0"
 
 def _config_path() -> str:
@@ -24,11 +26,8 @@ CONFIG_FILE = _config_path()
 # Ring diameters are in mm (not radii). Innermost ring first.
 
 def _targets_dir() -> str:
-    """Return the absolute path to the targets/ folder."""
-    import os
-    base = os.path.dirname(os.path.abspath(__file__))
-    base = os.path.dirname(base)  # up from core/ to project root
-    return os.path.join(base, "targets")
+    """Path to the bundled targets/ folder."""
+    return str(resource_path("targets"))
 
 
 def _load_target_csv(path: str) -> dict:

--- a/core/paths.py
+++ b/core/paths.py
@@ -69,3 +69,14 @@ def sessions_dir() -> Path:
     p = user_data_dir() / "sessions"
     p.mkdir(parents=True, exist_ok=True)
     return p
+
+
+def user_targets_dir() -> Path:
+    """User-writable targets/ folder, created on first access.
+
+    Bundled targets remain read-only seeds; targets created or edited
+    in-app are written here and merged at load time.
+    """
+    p = user_data_dir() / "targets"
+    p.mkdir(parents=True, exist_ok=True)
+    return p

--- a/core/paths.py
+++ b/core/paths.py
@@ -1,0 +1,71 @@
+"""Path resolution for source, PyInstaller and Nuitka builds.
+
+`resource_path` returns bundled read-only assets (targets/ etc).
+`user_data_dir` and friends return writable per-user paths following
+OS conventions. Set SPLATT2_USER_DIR to override the user dir.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+APP_NAME = "Splatt2"
+
+
+def is_frozen() -> bool:
+    """True when running from a PyInstaller or Nuitka bundle."""
+    return (getattr(sys, "frozen", False)
+            or hasattr(sys, "_MEIPASS")
+            or "__compiled__" in globals())
+
+
+def _bundle_root() -> Path:
+    # PyInstaller sets _MEIPASS to the bundle root (extracted temp dir
+    # for onefile, _internal/ for onedir). Source and Nuitka layouts
+    # both have core/ one level below the project root.
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        return Path(meipass)
+    return Path(__file__).resolve().parent.parent
+
+
+def resource_path(*parts: str) -> Path:
+    """Path to a bundled read-only asset, e.g. ``resource_path('targets')``."""
+    return _bundle_root().joinpath(*parts)
+
+
+def _platform_user_dir() -> Path:
+    override = os.environ.get("SPLATT2_USER_DIR")
+    if override:
+        return Path(override).expanduser()
+
+    if sys.platform.startswith("win"):
+        base = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        return Path(base) / APP_NAME
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / APP_NAME
+
+    base = os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local" / "share")
+    return Path(base) / APP_NAME
+
+
+def user_data_dir() -> Path:
+    """Per-user writable directory, created on first access."""
+    p = _platform_user_dir()
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def config_path() -> Path:
+    return user_data_dir() / "splatt2_config.json"
+
+
+def crash_log_path() -> Path:
+    return user_data_dir() / "splatt2_crash.log"
+
+
+def sessions_dir() -> Path:
+    """Default sessions/ folder, created on first access."""
+    p = user_data_dir() / "sessions"
+    p.mkdir(parents=True, exist_ok=True)
+    return p

--- a/main.py
+++ b/main.py
@@ -3,31 +3,44 @@ Splatt2 — DIY Target Shooting Trainer
 Entry point with crash logging.
 """
 
-import sys
 import os
+import shutil
+import sys
 import traceback
 
-# Ensure the project directory is on the path
 _BASE = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, _BASE)
+if _BASE not in sys.path:
+    sys.path.insert(0, _BASE)
 
 
-def _crash_log_path() -> str:
-    return os.path.join(_BASE, "splatt2_crash.log")
+def _migrate_legacy_crash_log(dst: str) -> None:
+    """Copy a pre-1.2 crash log from next to main.py into the user dir."""
+    if os.path.exists(dst):
+        return
+    legacy = os.path.join(_BASE, "splatt2_crash.log")
+    if os.path.isfile(legacy):
+        try:
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            shutil.copy2(legacy, dst)
+        except OSError:
+            pass
 
 
 def _write_crash_log(exc_text: str):
     import datetime
-    path = _crash_log_path()
+    from core.paths import crash_log_path
+
+    path = str(crash_log_path())
+    _migrate_legacy_crash_log(path)
     try:
         with open(path, "a", encoding="utf-8") as f:
-            f.write(f"\n{'='*60}\n")
+            f.write(f"\n{'=' * 60}\n")
             f.write(f"Crash at {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
-            f.write(f"{'='*60}\n")
+            f.write(f"{'=' * 60}\n")
             f.write(exc_text)
             f.write("\n")
         return path
-    except Exception:
+    except OSError:
         return None
 
 

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,5 @@
+# Build-time dependencies for packaging Splatt2.
+# Install alongside requirements.txt:
+#   pip install -r requirements.txt -r requirements-build.txt
+
+pyinstaller>=6.20

--- a/ui/app.py
+++ b/ui/app.py
@@ -2260,8 +2260,8 @@ class MarkerSheetDialog(tk.Toplevel):
         self._update_creator_preview()
 
     def _delete_target(self):
-        """Delete the selected existing target CSV."""
-        from core.config import TARGETS, _targets_dir
+        """Delete a user-created target CSV. Built-in targets can't be removed."""
+        from core.config import TARGETS, _user_targets_dir
         mode = self._c_mode.get()
         if mode == "New target":
             self._c_status.config(text="Select an existing target to delete.", fg=GOLD)
@@ -2270,29 +2270,33 @@ class MarkerSheetDialog(tk.Toplevel):
         t   = next((t for t in TARGETS.values() if t["name"] == key), None)
         if t is None:
             return
+        path = os.path.join(_user_targets_dir(), f"{t['key']}.csv")
+        if not os.path.isfile(path):
+            self._c_status.config(
+                text=f"'{t['name']}' is a built-in target and can't be deleted.",
+                fg=GOLD)
+            return
         if not messagebox.askyesno("Delete Target",
                 f"Permanently delete '{t['name']}' ({t['key']}.csv)?\n"
                 "This cannot be undone."):
             return
-        import os as _os
-        path = _os.path.join(_targets_dir(), f"{t['key']}.csv")
         try:
-            _os.remove(path)
+            os.remove(path)
             import core.config as _cc, core.marker_sheet as _ms
-            _cc.TARGETS.pop(t["key"], None)
+            # Reload — a built-in seed with the same key may now resurface.
+            _cc.TARGETS = _cc._load_all_targets()
             from core.marker_sheet import _get_aiming_marks
             _ms.AIMING_MARKS = _get_aiming_marks()
             self._c_status.config(text=f"Deleted '{t['name']}'.", fg=ACCENT)
-            # Refresh mode dropdown
             modes = ["New target"] + [f"Edit: {tgt['name']}" for tgt in _cc.TARGETS.values()]
             self._c_mode_combo["values"] = modes
             self._c_mode.set("New target")
-        except Exception as e:
+        except OSError as e:
             self._c_status.config(text=f"Delete failed: {e}", fg=ACCENT2)
 
     def _save_target(self):
-        """Validate and save the target as a CSV in the targets/ folder."""
-        from core.config import _targets_dir, _load_target_csv
+        """Validate and save the target as a CSV in the user targets dir."""
+        from core.config import _user_targets_dir, _load_target_csv
         import core.config as _cc, core.marker_sheet as _ms
 
         key  = self._c_key.get().strip().replace(" ","_")
@@ -2332,7 +2336,7 @@ class MarkerSheetDialog(tk.Toplevel):
             card_d = diameters[-1]
 
         # Check if overwriting a file
-        tdir  = _targets_dir()
+        tdir  = _user_targets_dir()
         os.makedirs(tdir, exist_ok=True)
         fname = f"{key}.csv"
         path  = os.path.join(tdir, fname)

--- a/ui/app.py
+++ b/ui/app.py
@@ -63,10 +63,10 @@ def _mk_btn(parent, text, cmd, accent=False, width=None):
 
 
 def _default_save_dir() -> str:
-    """sessions/ subfolder in the project root (next to main.py)."""
+    """Per-user sessions/ folder. Falls back to ~/Documents/Splatt2 on error."""
     try:
-        base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        return os.path.join(base, "sessions")
+        from core.paths import sessions_dir
+        return str(sessions_dir())
     except Exception:
         return os.path.join(os.path.expanduser("~"), "Documents", "Splatt2")
 


### PR DESCRIPTION
Adds PyInstaller to create packages so the end-user doesn't need to worry about installing Python etc.
Adds GitHub Actions workflows to create packages for Windows, macOS (arm64 and x64), and Linux on release (or manually). 

My testing can be found here: https://github.com/dsgnr/splatt2/releases/tag/v1.2.0-rc1 (download the relevant zip and open).

Most of the diff is fixing things that only break once the app is frozen.

Config and crash logs were being written next to `main.py`, which becomes _MEIPASS in a frozen build. Read-only and wiped on next launch.

Target Creator was also writing new CSVs into the bundled targets/ dir, which has the same problem and would overwrite user changes on reinstall.

`paths.py` now separates bundled resources from per-user data:

- Windows: `%APPDATA%`
- macOS: `~/Library/Application Support`
- Linux: `$XDG_DATA_HOME`

Can also be overridden with `SPLATT2_USER_DIR`.

Config, crash logs, sessions, and user targets now live there. Existing files get migrated on first launch and left in place afterwards.

Bundled targets are treated as read-only seed data. User targets override by key.

A few build details worth calling out:

- collect_all('sounddevice') pulls in the PortAudio binary
- PIL._tkinter_finder added as a hidden import
- `contents_directory='.'` avoids the extra _internal/ dir on Windows/Linux
- On macOS the loose COLLECT output gets discarded since Splatt2.app already contains it. Otherwise the release zip had roughly 50MB of duplicate files

Tested on macOS in both source and frozen modes, including migration paths. Windows and Linux currently only get smoke-tested in CI.