### PR TITLE
Define marker sheet DPI metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    name: Syntax check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Compile all Python sources
+        run: python -m compileall -q core ui main.py build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,9 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact: splatt2-linux-x64
-          - os: macos-latest
+          - os: macos-26
             artifact: splatt2-macos-arm64
-          - os: macos-13
+          - os: macos-26-intel
             artifact: splatt2-macos-x64
           - os: windows-latest
             artifact: splatt2-windows-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      publish_release:
+        description: "Create a GitHub Release and attach the built zips"
+        type: boolean
+        default: false
+      release_tag:
+        description: "Tag for the release when publish_release is true (e.g. v1.2.0-rc1)"
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: splatt2-linux-x64
+          - os: macos-latest
+            artifact: splatt2-macos-arm64
+          - os: macos-13
+            artifact: splatt2-macos-x64
+          - os: windows-latest
+            artifact: splatt2-windows-x64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-build.txt
+
+      - name: Install Linux runtime deps
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgl1 libglib2.0-0 \
+            libportaudio2 \
+            python3-tk
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-build.txt
+
+      - name: Build with PyInstaller
+        run: python build/build.py --clean
+
+      - name: Package artifact (zip)
+        if: runner.os != 'macOS'
+        shell: bash
+        run: |
+          cd dist
+          for d in splatt2-*/; do
+            d="${d%/}"
+            python -c "import shutil; shutil.make_archive('${d}', 'zip', '.', '${d}')"
+          done
+          ls -la
+
+      - name: Package artifact (zip, macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          cd dist
+          for d in splatt2-*/; do
+            d="${d%/}"
+            ditto -c -k --sequesterRsrc --keepParent "${d}" "${d}.zip"
+          done
+          ls -la
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist/*.zip
+          if-no-files-found: error
+          retention-days: 30
+
+  release:
+    name: Publish GitHub Release
+    needs: build
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.publish_release == true)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate manual-dispatch inputs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ -z "${{ inputs.release_tag }}" ]; then
+            echo "::error::publish_release was ticked but release_tag is empty"
+            exit 1
+          fi
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: >-
+            ${{ github.event_name == 'workflow_dispatch'
+                && inputs.release_tag
+                || github.ref_name }}
+          files: artifacts/**/*.zip
+          generate_release_notes: true
+          prerelease: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ desktop.ini
 
 # Generated images (from marker sheet dialog)
 aruco_sheet*.png
+
+# Build artifacts
+dist/
+build/_pyinstaller_work/
+build/icons/

--- a/README.md
+++ b/README.md
@@ -34,22 +34,48 @@ Changing the pellet calibre in Settings instantly shifts all scoring bands — o
 
 ## Requirements
 
-- Windows 10 or 11 (64-bit)
-- **Python 3.9+** — download from https://python.org — tick **"Add Python to PATH"** during installation
+- Windows 10/11, macOS 12+, or a recent 64-bit Linux desktop
 - A webcam (USB recommended for barrel-mounting; built-in works for testing)
 - A microphone (built-in laptop mic is fine for dry-fire; closer to the action is better for live fire)
+- **Python 3.9+** is only needed when running from source — pre-built binaries bundle their own runtime
 
 ---
 
-## Quick Start
+## Quick Start (pre-built binary)
 
-1. Install Python from https://python.org (tick "Add Python to PATH")
-2. Download or clone this repository
-3. Double-click **`RUN.bat`**
+Download the latest release for your OS from the [Releases page](../../releases/latest):
 
-That's it. `RUN.bat` automatically installs all Python dependencies (`numpy`, `opencv`, `sounddevice`, `Pillow`, `scipy`) the first time it runs, then launches Splatt2. On subsequent runs it checks for updates to dependencies and starts immediately.
+- `splatt2-windows-x64.zip`
+- `splatt2-macos-arm64.zip` (Apple Silicon) or `splatt2-macos-x64.zip` (Intel)
+- `splatt2-linux-x64.zip`
 
-> **To share with someone else:** give them the folder and tell them to install Python and double-click `RUN.bat`. No compilation, no installers, no antivirus drama.
+Unzip anywhere and launch:
+
+- **Windows** — run `splatt2.exe`
+- **macOS** — open `Splatt2.app` (right-click → Open the first time so Gatekeeper allows the unsigned bundle)
+- **Linux** — `chmod +x splatt2 && ./splatt2`
+
+User config and shooting sessions are saved to your OS-native app data folder:
+
+| OS      | Location                                               |
+| ------- | ------------------------------------------------------ |
+| Windows | `%APPDATA%\Splatt2`                                    |
+| macOS   | `~/Library/Application Support/Splatt2`                |
+| Linux   | `~/.local/share/Splatt2` (or `$XDG_DATA_HOME/Splatt2`) |
+
+Override with `SPLATT2_USER_DIR=/some/path` for testing or portable installs.
+
+---
+
+## Quick Start (run from source)
+
+1. Install Python 3.9+ from https://python.org (Windows: tick **"Add Python to PATH"**)
+2. Clone or download this repository
+3. Launch:
+   - **Windows** — double-click `RUN.bat`
+   - **macOS / Linux** — `pip install -r requirements.txt && python main.py`
+
+`RUN.bat` installs the Python deps (`numpy`, `opencv`, `sounddevice`, `Pillow`, `scipy`) on first run, then starts the app.
 
 ---
 
@@ -252,9 +278,11 @@ Open **Print Marker Sheet → Target Creator** tab to create or edit targets wit
 
 ## Session Files
 
-Sessions are saved in the `sessions/` folder (next to the app, or as configured in Settings). Each day of shooting creates a subfolder named `YYYY-MM-DD/`. Within each day, each series is a separate file named `HH-MM-SS_name_series1.csv`.
+Series recordings are saved to the `sessions/` folder inside your user data directory (see *Quick Start (pre-built binary)* for the per-OS path), or in a custom location configured in Settings → Session. Each day of shooting creates a subfolder named `YYYY-MM-DD/`. Within each day, each series is a separate file named `HH-MM-SS_name_series1.csv`.
 
 Each `.csv` has a companion `.json` file with full trace data for the Series Review window.
+
+> Splatt2 versions before this one stored the config and `sessions/` folder next to `main.py`. On first launch of a newer build, the config is migrated into the per-user app data directory automatically. The original is left in place.
 
 ---
 
@@ -313,13 +341,19 @@ Each `.csv` has a companion `.json` file with full trace data for the Series Rev
 ```
 splatt2/
 ├── main.py                  Entry point with crash logging
-├── RUN.bat                  Install dependencies & launch (double-click to run)
-├── requirements.txt         Python dependencies
-├── targets/                 Target definition CSV files — add your own here
+├── RUN.bat                  Install dependencies & launch (Windows dev flow)
+├── requirements.txt         Runtime Python dependencies
+├── requirements-build.txt   Build-time dependencies (PyInstaller)
+├── targets/                 Bundled target definition CSVs (read-only seeds)
 │   ├── 10m_air_rifle.csv
 │   ├── 10m_air_pistol.csv
 │   └── 6yd_air_rifle.csv
+├── build/
+│   ├── splatt2.spec         PyInstaller spec
+│   ├── build.py             Cross-platform build script
+│   └── README.md            Build instructions
 ├── core/
+│   ├── paths.py             Cross-platform resource and user-data paths
 │   ├── config.py            Settings management and target CSV loader
 │   ├── tracker.py           ArUco detection, homography, scoring geometry
 │   ├── audio.py             Shot sound detection (transient detection)
@@ -327,9 +361,38 @@ splatt2/
 │   ├── target_renderer.py   OpenCV target canvas drawing
 │   ├── marker_sheet.py      Printable ArUco sheet generator
 │   └── smoother.py          Aim-point smoothing (EMA / Savitzky-Golay)
-└── ui/
-    └── app.py               Main tkinter UI
+├── ui/
+│   └── app.py               Main tkinter UI
+└── .github/workflows/
+    ├── ci.yml               Syntax check on push and PR
+    └── release.yml          Cross-platform PyInstaller builds on tag
 ```
+
+---
+
+## Building from Source
+
+To produce a standalone bundle for your platform:
+
+```
+pip install -r requirements.txt -r requirements-build.txt
+python build/build.py --clean
+```
+
+Output lands in `dist/splatt2-<os>-<arch>/`. See [`build/README.md`](build/README.md) for per-OS notes.
+
+Pre-built binaries are produced automatically by GitHub Actions on every tag — see [`.github/workflows/release.yml`](.github/workflows/release.yml).
+
+### On-demand builds via GitHub Actions
+
+You can trigger the release workflow manually without pushing a tag:
+
+1. Go to **Actions → Release → Run workflow**
+2. Pick the branch
+3. Leave **Create a GitHub Release** unticked to just produce downloadable artifacts attached to the workflow run (kept for 30 days)
+4. Tick it and supply a tag (e.g. `v1.2.0-rc1`) to publish a pre-release with the zips attached
+
+Manual-dispatch releases are flagged as pre-releases so they don't override the latest stable.
 
 ---
 

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,52 @@
+# Build
+
+Cross-platform PyInstaller build of Splatt2 for the host OS.
+
+## Prerequisites
+
+```
+pip install -r requirements.txt -r requirements-build.txt
+```
+
+Platform notes:
+
+- **Linux** — install system tk and PortAudio runtime libs:
+  `sudo apt-get install python3-tk libportaudio2`
+- **macOS** — Xcode Command Line Tools (for codesigning).
+- **Windows** — no extras; PyInstaller wheels include the bootloader.
+
+## Build
+
+```
+python build/build.py            # build for the current OS
+python build/build.py --clean    # delete dist/ and build cache first
+```
+
+Output:
+
+```
+dist/splatt2-<os>-<arch>/
+```
+
+On macOS the directory contains `Splatt2.app` (the launchable bundle)
+plus the underlying onedir layout used by the bootloader. On Windows
+and Linux the binary is `splatt2(.exe)` alongside `_internal/`.
+
+## Files
+
+- `build/splatt2.spec` — PyInstaller spec, single source of truth for
+  what gets bundled (data files, hidden imports, per-OS branches).
+- `build/build.py` — wrapper around `pyinstaller` that handles cleanup
+  and renames the output to a stable per-platform directory name.
+
+## Icons
+
+Drop platform icons into `build/icons/`:
+
+```
+build/icons/splatt2.ico    Windows
+build/icons/splatt2.icns   macOS
+build/icons/splatt2.png    Linux
+```
+
+If absent the build still succeeds with PyInstaller's defaults.

--- a/build/build.py
+++ b/build/build.py
@@ -1,0 +1,100 @@
+"""
+Cross-platform PyInstaller build entry point for Splatt2.
+
+Usage:
+    python build/build.py            # build for the current OS
+    python build/build.py --clean    # delete dist/ and build cache first
+
+Output:
+    dist/splatt2-<os>-<arch>/        # onedir bundle, ready to zip
+
+The spec file (build/splatt2.spec) holds the actual build description.
+This script handles cleanup, output renaming, and tagging by OS/arch so
+CI and local builds produce identically-named artifacts.
+"""
+
+import argparse
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SPEC = ROOT / "build" / "splatt2.spec"
+DIST = ROOT / "dist"
+WORK = ROOT / "build" / "_pyinstaller_work"
+
+
+def _os_tag() -> str:
+    if sys.platform.startswith("win"):
+        return "windows"
+    if sys.platform == "darwin":
+        return "macos"
+    return "linux"
+
+
+def _arch_tag() -> str:
+    m = platform.machine().lower()
+    return {
+        "amd64": "x64", "x86_64": "x64",
+        "arm64": "arm64", "aarch64": "arm64",
+    }.get(m, m or "unknown")
+
+
+def _rename_output(target_name: str) -> Path:
+    """Move PyInstaller's per-OS output into dist/splatt2-<os>-<arch>/.
+
+    On macOS the BUNDLE step produces ``dist/Splatt2.app`` — the artifact
+    end users actually launch. It's moved inside the target folder so
+    every platform produces a single zippable directory.
+    """
+    src = DIST / "splatt2"
+    dst = DIST / target_name
+    if dst.exists():
+        shutil.rmtree(dst)
+    if src.exists():
+        src.rename(dst)
+
+    if sys.platform == "darwin":
+        app = DIST / "Splatt2.app"
+        if app.exists():
+            dst.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(app), str(dst / "Splatt2.app"))
+    return dst
+
+
+def _build(clean: bool) -> int:
+    if clean:
+        for p in (DIST, WORK):
+            if p.exists():
+                print(f"[build] Removing {p}")
+                shutil.rmtree(p)
+
+    cmd = [
+        sys.executable, "-m", "PyInstaller",
+        "--noconfirm",
+        f"--distpath={DIST}",
+        f"--workpath={WORK}",
+        str(SPEC),
+    ]
+    print("[build] " + " ".join(cmd))
+    rc = subprocess.call(cmd, cwd=ROOT)
+    if rc != 0:
+        return rc
+
+    target = f"splatt2-{_os_tag()}-{_arch_tag()}"
+    out = _rename_output(target)
+    print(f"[build] Output: {out}")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Build Splatt2 with PyInstaller")
+    p.add_argument("--clean", action="store_true",
+                   help="Delete dist/ and build cache before building")
+    return _build(p.parse_args().clean)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/build.py
+++ b/build/build.py
@@ -43,24 +43,29 @@ def _arch_tag() -> str:
 
 
 def _rename_output(target_name: str) -> Path:
-    """Move PyInstaller's per-OS output into dist/splatt2-<os>-<arch>/.
+    """Stage the platform-specific output under dist/splatt2-<os>-<arch>/.
 
-    On macOS the BUNDLE step produces ``dist/Splatt2.app`` — the artifact
-    end users actually launch. It's moved inside the target folder so
-    every platform produces a single zippable directory.
+    On macOS the launchable artifact is ``dist/Splatt2.app`` produced by
+    the BUNDLE step; the loose COLLECT directory only duplicates what's
+    already inside the bundle, so it's dropped. On Windows and Linux
+    the COLLECT directory IS the artifact.
     """
     src = DIST / "splatt2"
     dst = DIST / target_name
     if dst.exists():
         shutil.rmtree(dst)
-    if src.exists():
-        src.rename(dst)
 
     if sys.platform == "darwin":
+        dst.mkdir(parents=True, exist_ok=True)
         app = DIST / "Splatt2.app"
         if app.exists():
-            dst.mkdir(parents=True, exist_ok=True)
             shutil.move(str(app), str(dst / "Splatt2.app"))
+        if src.exists():
+            shutil.rmtree(src)
+    else:
+        if src.exists():
+            src.rename(dst)
+
     return dst
 
 

--- a/build/splatt2.spec
+++ b/build/splatt2.spec
@@ -62,6 +62,7 @@ exe = EXE(
     console=False,
     disable_windowed_traceback=False,
     icon=icon_arg,
+    contents_directory=".",
 )
 
 coll = COLLECT(

--- a/build/splatt2.spec
+++ b/build/splatt2.spec
@@ -1,0 +1,89 @@
+# PyInstaller spec for Splatt2.
+#
+# Run via build/build.py rather than directly so the working dir, output
+# layout and platform tweaks are consistent.
+
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_all, collect_submodules
+
+ROOT = Path(SPECPATH).parent
+APP_NAME = "splatt2"
+ENTRY = str(ROOT / "main.py")
+
+datas = [(str(ROOT / "targets"), "targets")]
+binaries = []
+hiddenimports = [
+    # Pillow's tkinter integration is loaded dynamically.
+    "PIL._tkinter_finder",
+]
+
+# sounddevice ships its own PortAudio binary in _sounddevice_data/.
+sd_datas, sd_binaries, sd_hidden = collect_all("sounddevice")
+datas += sd_datas
+binaries += sd_binaries
+hiddenimports += sd_hidden
+
+# scipy uses lazy submodule imports that PyInstaller's tracer misses.
+hiddenimports += collect_submodules("scipy")
+
+
+a = Analysis(
+    [ENTRY],
+    pathex=[str(ROOT)],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+
+_icon_dir = ROOT / "build" / "icons"
+if sys.platform.startswith("win"):
+    _icon = _icon_dir / "splatt2.ico"
+elif sys.platform == "darwin":
+    _icon = _icon_dir / "splatt2.icns"
+else:
+    _icon = _icon_dir / "splatt2.png"
+icon_arg = str(_icon) if _icon.exists() else None
+
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name=APP_NAME,
+    console=False,
+    disable_windowed_traceback=False,
+    icon=icon_arg,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    name=APP_NAME,
+)
+
+if sys.platform == "darwin":
+    app = BUNDLE(
+        coll,
+        name="Splatt2.app",
+        bundle_identifier="com.splatt2.app",
+        icon=icon_arg,
+        info_plist={
+            "CFBundleName": "Splatt2",
+            "CFBundleDisplayName": "Splatt2",
+            "NSHighResolutionCapable": True,
+            "NSCameraUsageDescription":
+                "Splatt2 uses the camera to track the rifle's aim point.",
+            "NSMicrophoneUsageDescription":
+                "Splatt2 uses the microphone to detect the shot click.",
+        },
+    )

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,6 @@
+"""Core domain logic for Splatt2.
+
+Modules in this package are independent of any UI framework. They handle
+configuration, paths, audio detection, tracking, scoring, smoothing,
+session bookkeeping and rendering.
+"""

--- a/core/audio.py
+++ b/core/audio.py
@@ -1,23 +1,20 @@
-"""
-core/audio.py
-Shot detection via transient (percussive click) detection.
+"""Shot detection from microphone audio.
 
-For dry-firing, a click is a very short-duration, high-amplitude transient —
-not a sustained loud noise. The detector works by:
-  1. Tracking a rolling RMS baseline (ambient noise floor)
-  2. Computing a short-window peak
-  3. Firing when peak / baseline > transient_ratio AND peak > abs_threshold
-  4. Enforcing a cooldown to prevent double-triggers
-
-This approach rejects: sustained talking, chair noise, HVAC hum.
-It accepts: a sharp click/snap that is N× louder than the room baseline.
+A shot click is a short, sharp transient: very high amplitude over a very
+short window. The detector tracks a rolling RMS baseline and fires when a
+peak both exceeds an absolute threshold and is several times louder than
+the baseline. This rejects steady-state noise (talking, fans) while
+accepting genuine clicks.
 """
 
+from __future__ import annotations
+
+import collections
 import threading
 import time
-import collections
+from typing import Callable, Deque, Optional
+
 import numpy as np
-from typing import Callable, Optional, Deque
 
 try:
     import sounddevice as sd
@@ -25,19 +22,26 @@ try:
 except ImportError:
     SD_AVAILABLE = False
 
-WAVEFORM_SAMPLES = 300   # history length for waveform display (frames)
+
+WAVEFORM_SAMPLES = 300
+"""Number of recent RMS values kept for the live waveform display."""
 
 
 class AudioDetector:
-    """
-    Parameters
-    ----------
-    threshold        : absolute peak threshold (0–1). Acts as a floor —
-                       quiet rooms can use 0.05, louder rooms 0.15–0.3.
-    transient_ratio  : peak must be this many times the rolling baseline RMS.
-                       Typical: 4–8. Higher = only sharp spikes trigger.
-    cooldown_ms      : min ms between triggers
-    baseline_window  : number of chunks used for rolling baseline
+    """Detect gunshot-like transients on a microphone input stream.
+
+    Args:
+        threshold: Absolute peak floor in [0, 1]. Quiet rooms can use 0.05;
+            louder ones 0.15-0.3.
+        transient_ratio: Peak must exceed the rolling baseline RMS by this
+            factor before triggering. Higher values reject steadier sounds.
+        cooldown_ms: Minimum time between successive triggers.
+        sample_rate: Microphone sample rate in Hz.
+        chunk_size: Samples per callback. ~12 ms at 44.1 kHz keeps latency
+            low while still capturing the full transient.
+        device_index: Input device index, or ``None`` for the system default.
+        on_shot: Callback invoked with the trigger timestamp when a shot is
+            detected.
     """
 
     def __init__(
@@ -46,9 +50,9 @@ class AudioDetector:
         transient_ratio: float = 6.0,
         cooldown_ms: int = 800,
         sample_rate: int = 44100,
-        chunk_size: int = 512,            # ~12ms chunks — low latency transient detection
+        chunk_size: int = 512,
         device_index: Optional[int] = None,
-        on_shot: Optional[Callable] = None,
+        on_shot: Optional[Callable[[float], None]] = None,
     ):
         self.threshold = threshold
         self.transient_ratio = transient_ratio
@@ -64,21 +68,20 @@ class AudioDetector:
         self._paused = False
         self._lock = threading.Lock()
 
-        # Live display data (thread-safe via deque)
-        self.current_level: float = 0.0       # latest RMS (for bar meter)
-        self.current_peak: float = 0.0        # latest peak
-        self.current_baseline: float = 0.0    # rolling baseline
-        self.last_trigger_level: float = 0.0  # peak at last trigger
+        # Live display state, read by the UI thread.
+        self.current_level: float = 0.0
+        self.current_peak: float = 0.0
+        self.current_baseline: float = 0.0
+        self.last_trigger_level: float = 0.0
         self._waveform: Deque[float] = collections.deque(
             [0.0] * WAVEFORM_SAMPLES, maxlen=WAVEFORM_SAMPLES)
 
-        # Rolling baseline: median of recent chunk RMSes
+        # Rolling baseline: percentile over recent chunk RMSes.
         self._baseline_buf: Deque[float] = collections.deque(
             [0.001] * 40, maxlen=40)
 
-    # ── Public API ────────────────────────────────────────────────────────────
-
-    def start(self):
+    def start(self) -> None:
+        """Open the input stream and begin processing audio."""
         if not SD_AVAILABLE:
             print("[Audio] sounddevice not available.")
             return
@@ -99,7 +102,8 @@ class AudioDetector:
             print(f"[Audio] Stream error: {e}")
             self._running = False
 
-    def stop(self):
+    def stop(self) -> None:
+        """Stop and close the input stream."""
         self._running = False
         if self._stream is not None:
             try:
@@ -109,56 +113,51 @@ class AudioDetector:
                 pass
             self._stream = None
 
-    def pause(self, paused: bool):
+    def pause(self, paused: bool) -> None:
+        """Suspend or resume trigger detection without closing the stream."""
         with self._lock:
             self._paused = paused
 
-    def set_threshold(self, value: float):
+    def set_threshold(self, value: float) -> None:
         self.threshold = max(0.005, min(1.0, value))
 
-    def set_transient_ratio(self, value: float):
+    def set_transient_ratio(self, value: float) -> None:
         self.transient_ratio = max(1.5, min(20.0, value))
 
-    def set_cooldown(self, ms: int):
+    def set_cooldown(self, ms: int) -> None:
         self.cooldown_s = ms / 1000.0
 
     def get_waveform(self) -> list:
-        """Return recent normalised amplitude history for display."""
+        """Snapshot of the most recent RMS history."""
         return list(self._waveform)
 
     @staticmethod
-    def list_devices():
+    def list_devices() -> list:
+        """Available input devices as ``(index, name)`` tuples."""
         if not SD_AVAILABLE:
             return []
-        devs = []
         try:
-            for i, d in enumerate(sd.query_devices()):
-                if d["max_input_channels"] > 0:
-                    devs.append((i, d["name"]))
+            return [
+                (i, d["name"]) for i, d in enumerate(sd.query_devices())
+                if d["max_input_channels"] > 0
+            ]
         except Exception:
-            pass
-        return devs
+            return []
 
-    # ── Internal ──────────────────────────────────────────────────────────────
-
-    def _audio_callback(self, indata, frames, time_info, status):
+    def _audio_callback(self, indata, frames, time_info, status) -> None:
         if not any(indata):
             return
 
         audio = indata[:, 0].astype(np.float32)
-
-        rms  = float(np.sqrt(np.mean(audio ** 2)))
+        rms = float(np.sqrt(np.mean(audio ** 2)))
         peak = float(np.max(np.abs(audio)))
 
-        # Update waveform ring buffer (downsampled to one value per chunk)
         self._waveform.append(rms)
-
-        # Update rolling baseline with slow-reacting median
         self._baseline_buf.append(rms)
         baseline = float(np.percentile(list(self._baseline_buf), 60))
 
-        self.current_level    = rms
-        self.current_peak     = peak
+        self.current_level = rms
+        self.current_peak = peak
         self.current_baseline = baseline
 
         with self._lock:
@@ -166,17 +165,19 @@ class AudioDetector:
         if paused:
             return
 
-        # Trigger condition:
-        #   1. Absolute peak exceeds threshold floor
-        #   2. Peak-to-baseline ratio exceeds transient_ratio (percussive test)
         ratio = peak / max(baseline, 1e-6)
-        if peak >= self.threshold and ratio >= self.transient_ratio:
-            now = time.time()
-            if now - self._last_trigger_time >= self.cooldown_s:
-                self._last_trigger_time = now
-                self.last_trigger_level = peak
-                if self.on_shot:
-                    try:
-                        self.on_shot(now)
-                    except Exception as e:
-                        print(f"[Audio] callback error: {e}")
+        if peak < self.threshold or ratio < self.transient_ratio:
+            return
+
+        now = time.time()
+        if now - self._last_trigger_time < self.cooldown_s:
+            return
+
+        self._last_trigger_time = now
+        self.last_trigger_level = peak
+        if self.on_shot is None:
+            return
+        try:
+            self.on_shot(now)
+        except Exception as e:
+            print(f"[Audio] callback error: {e}")

--- a/core/config.py
+++ b/core/config.py
@@ -243,7 +243,7 @@ DEFAULT_CONFIG = {
     "session_name":       "Session",
     "shooter_name":       "",
     "shots_per_series":   10,
-    "save_directory":     "",    # empty = sessions/ folder next to the app
+    "save_directory":     "",    # empty = sessions/ folder in user data dir
 }
 
 

--- a/core/config.py
+++ b/core/config.py
@@ -7,7 +7,7 @@ import json
 import os
 import shutil
 
-from core.paths import config_path, resource_path
+from core.paths import config_path, resource_path, user_targets_dir
 
 VERSION = "1.1.0"
 
@@ -38,8 +38,13 @@ _migrate_legacy_config()
 # Ring diameters are in mm (not radii). Innermost ring first.
 
 def _targets_dir() -> str:
-    """Path to the bundled targets/ folder."""
+    """Path to the bundled targets/ folder (read-only seeds)."""
     return str(resource_path("targets"))
+
+
+def _user_targets_dir() -> str:
+    """Path to the user-writable targets/ folder."""
+    return str(user_targets_dir())
 
 
 def _load_target_csv(path: str) -> dict:
@@ -143,19 +148,21 @@ def _load_target_csv(path: str) -> dict:
     }
 
 def _load_all_targets() -> dict:
-    """Load all .csv files from the targets/ folder. Returns {key: target_dict}."""
-    tdir = _targets_dir()
+    """Load targets from the bundled and user dirs.
+
+    User files override bundled files when keys collide, so a shooter
+    can tweak a built-in target without losing the original.
+    """
     targets = {}
-    if not os.path.isdir(tdir):
-        print(f"[Targets] Folder not found: {tdir}")
-        return targets
-    for fname in sorted(os.listdir(tdir)):
-        if not fname.lower().endswith(".csv"):
+    for tdir in (_targets_dir(), _user_targets_dir()):
+        if not os.path.isdir(tdir):
             continue
-        path = os.path.join(tdir, fname)
-        t = _load_target_csv(path)
-        if t:
-            targets[t["key"]] = t
+        for fname in sorted(os.listdir(tdir)):
+            if not fname.lower().endswith(".csv"):
+                continue
+            t = _load_target_csv(os.path.join(tdir, fname))
+            if t:
+                targets[t["key"]] = t
     return targets
 
 

--- a/core/config.py
+++ b/core/config.py
@@ -5,19 +5,31 @@ All user-configurable settings and target definitions.
 
 import json
 import os
+import shutil
 
-from core.paths import resource_path
+from core.paths import config_path, resource_path
 
 VERSION = "1.1.0"
 
-def _config_path() -> str:
-    """Config file lives in the project root (next to main.py)."""
-    import os
-    base = os.path.dirname(os.path.abspath(__file__))
-    base = os.path.dirname(base)  # up from core/ to project root
-    return os.path.join(base, "splatt2_config.json")
+CONFIG_FILE = str(config_path())
 
-CONFIG_FILE = _config_path()
+
+def _migrate_legacy_config() -> None:
+    """Copy a pre-1.2 config sitting next to main.py into the user dir."""
+    if os.path.exists(CONFIG_FILE):
+        return
+    legacy = os.path.join(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__))), "splatt2_config.json")
+    if os.path.isfile(legacy):
+        try:
+            os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
+            shutil.copy2(legacy, CONFIG_FILE)
+            print(f"[Config] Migrated legacy config -> {CONFIG_FILE}")
+        except OSError as e:
+            print(f"[Config] Could not migrate legacy config: {e}")
+
+
+_migrate_legacy_config()
 
 # ── Target definitions — loaded from targets/ folder ────────────────────────
 # Each .csv in the targets/ folder defines one target.
@@ -244,6 +256,7 @@ def load_config():
 
 def save_config(cfg: dict):
     try:
+        os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
         with open(CONFIG_FILE, "w") as f:
             json.dump(cfg, f, indent=2)
     except Exception as e:

--- a/core/config.py
+++ b/core/config.py
@@ -143,6 +143,12 @@ def load_target_csv(path: str) -> Optional[dict]:
     ring_labels = [str(int(s)) if s == int(s) else str(s) for s in scores]
     mark_count = int(meta.get("mark_count", 1))
 
+    # Optional explicit bull diameter for the renderer; targets that
+    # don't set this fall back to the historical "outer 4 rings dark,
+    # inner 6 rings light" rule applied in TargetRenderer.
+    bull_dia = meta.get("bull_dia_mm")
+    bull_dia = float(bull_dia) if bull_dia is not None else None
+
     return {
         "name": meta["name"],
         "key": meta["key"],
@@ -153,6 +159,7 @@ def load_target_csv(path: str) -> Optional[dict]:
         "calibre_mm": float(meta.get("calibre_mm", 4.5)),
         "reference_dist_m": float(meta.get("reference_dist_m", 10.0)),
         "aiming_mark_dia_mm": aiming_dia,
+        "bull_dia_mm": bull_dia,
         "outer_ring_dia_mm": outer_dia,
         "rings_dia_mm": unique_dias,
         "ring_labels": ring_labels,

--- a/core/config.py
+++ b/core/config.py
@@ -6,6 +6,8 @@ All user-configurable settings and target definitions.
 import json
 import os
 
+from core.paths import resource_path
+
 VERSION = "1.1.0"
 
 def _config_path() -> str:
@@ -24,11 +26,8 @@ CONFIG_FILE = _config_path()
 # Ring diameters are in mm (not radii). Innermost ring first.
 
 def _targets_dir() -> str:
-    """Return the absolute path to the targets/ folder."""
-    import os
-    base = os.path.dirname(os.path.abspath(__file__))
-    base = os.path.dirname(base)  # up from core/ to project root
-    return os.path.join(base, "targets")
+    """Path to the bundled targets/ folder."""
+    return str(resource_path("targets"))
 
 
 def _load_target_csv(path: str) -> dict:

--- a/core/config.py
+++ b/core/config.py
@@ -1,11 +1,19 @@
+"""User configuration and target catalogue.
+
+Targets are loaded from CSV files in two locations: a read-only seed
+directory bundled with the app, and a user-writable directory under the
+app data folder. User files override seeds with the same key, so a
+shooter can tweak a built-in target without losing the original.
+
+The runtime config is a plain JSON dict persisted to the user data dir.
 """
-Splatt2 Configuration
-All user-configurable settings and target definitions.
-"""
+
+from __future__ import annotations
 
 import json
 import os
 import shutil
+from typing import Iterable, Optional, Tuple
 
 from core.paths import config_path, resource_path, user_targets_dir
 
@@ -15,55 +23,93 @@ CONFIG_FILE = str(config_path())
 
 
 def _migrate_legacy_config() -> None:
-    """Copy a pre-1.2 config sitting next to main.py into the user dir."""
+    """Copy any pre-1.2 config beside ``main.py`` into the user data dir."""
     if os.path.exists(CONFIG_FILE):
         return
-    legacy = os.path.join(os.path.dirname(os.path.dirname(
-        os.path.abspath(__file__))), "splatt2_config.json")
-    if os.path.isfile(legacy):
-        try:
-            os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
-            shutil.copy2(legacy, CONFIG_FILE)
-            print(f"[Config] Migrated legacy config -> {CONFIG_FILE}")
-        except OSError as e:
-            print(f"[Config] Could not migrate legacy config: {e}")
+    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    legacy = os.path.join(project_root, "splatt2_config.json")
+    if not os.path.isfile(legacy):
+        return
+    try:
+        os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
+        shutil.copy2(legacy, CONFIG_FILE)
+        print(f"[Config] Migrated legacy config -> {CONFIG_FILE}")
+    except OSError as e:
+        print(f"[Config] Could not migrate legacy config: {e}")
 
 
 _migrate_legacy_config()
 
-# ── Target definitions — loaded from targets/ folder ────────────────────────
-# Each .csv in the targets/ folder defines one target.
-# Format: header rows (key=value), then a blank line,
-#         then "score,ring_diameter_mm" header, then data rows.
-# Ring diameters are in mm (not radii). Innermost ring first.
 
-def _targets_dir() -> str:
-    """Path to the bundled targets/ folder (read-only seeds)."""
+# Target CSV layout
+# -----------------
+# Header rows in ``key=value`` form, then a separator header, then data
+# rows. Two header forms are accepted::
+#
+#     score,ring_diameter_mm
+#     score_integer,score_decimal,ring_diameter_mm
+#
+# Ring diameters are visual only; scoring geometry is computed at runtime
+# from ``card_diameter_mm`` and the configured pellet calibre.
+
+_DATA_HEADERS = (
+    "score,ring_diameter_mm",
+    "score_integer,score_decimal,ring_diameter_mm",
+)
+
+
+def bundled_targets_dir() -> str:
+    """Read-only directory of bundled target CSVs."""
     return str(resource_path("targets"))
 
 
-def _user_targets_dir() -> str:
-    """Path to the user-writable targets/ folder."""
+def writable_targets_dir() -> str:
+    """User-writable directory of target CSVs."""
     return str(user_targets_dir())
 
 
-def _load_target_csv(path: str) -> dict:
-    """
-    Parse a single target CSV file.
+# Backwards-compatible aliases used by the UI module.
+_targets_dir = bundled_targets_dir
+_user_targets_dir = writable_targets_dir
 
-    Header rows (key=value), then a blank line, then:
-        score,ring_diameter_mm
-        10,0.5
-        9,5.5
-        ...
 
-    ring_diameter_mm values are the VISUAL ring boundaries (mm diameter).
-    Scoring geometry is computed at runtime from card_diameter_mm + calibre.
-    """
-    meta = {}
-    scores    = []
-    diameters = []
-    in_data   = False
+def _parse_csv_row(parts: list) -> Optional[Tuple[float, float]]:
+    """Return ``(score, diameter_mm)`` for a CSV data row, or ``None``."""
+    if len(parts) == 2:
+        return float(parts[0]), float(parts[1])
+    if len(parts) == 3:
+        # Legacy three-column format: score_integer, score_decimal, diameter.
+        return float(parts[0]), float(parts[2])
+    return None
+
+
+def _quincunx_offsets(spacing_mm: float) -> list:
+    """Five mark centres in a quincunx pattern at the given spacing."""
+    h = spacing_mm / 2
+    return [
+        (-h, -h), (+h, -h),
+        (0.0, 0.0),
+        (-h, +h), (+h, +h),
+    ]
+
+
+def _resolve_mark_offsets(meta: dict) -> Optional[list]:
+    """Build mark centres for a multi-mark target, or ``None``."""
+    mark_count = int(meta.get("mark_count", 1))
+    if mark_count <= 1:
+        return None
+    spacing = float(meta.get("mark_spacing_mm", 75.0))
+    if mark_count == 5:
+        return _quincunx_offsets(spacing)
+    return None
+
+
+def load_target_csv(path: str) -> Optional[dict]:
+    """Parse a single target CSV into a target dict, or ``None`` on error."""
+    meta: dict = {}
+    scores: list = []
+    diameters: list = []
+    in_data = False
 
     try:
         with open(path, newline="", encoding="utf-8") as f:
@@ -71,21 +117,14 @@ def _load_target_csv(path: str) -> dict:
                 line = raw.strip()
                 if not line or line.startswith("#"):
                     continue
-                low = line.lower()
-                # Accept both old and new header names
-                if low in ("score,ring_diameter_mm",
-                           "score_integer,score_decimal,ring_diameter_mm"):
+                if line.lower() in _DATA_HEADERS:
                     in_data = True
                     continue
                 if in_data:
-                    parts = [p.strip() for p in line.split(",")]
-                    # Old two-column format: take only first and last columns
-                    if len(parts) == 3:
-                        scores.append(float(parts[0]))
-                        diameters.append(float(parts[2]))
-                    elif len(parts) == 2:
-                        scores.append(float(parts[0]))
-                        diameters.append(float(parts[1]))
+                    row = _parse_csv_row([p.strip() for p in line.split(",")])
+                    if row is not None:
+                        scores.append(row[0])
+                        diameters.append(row[1])
                 else:
                     parts = line.split(",", 1)
                     if len(parts) == 2:
@@ -97,171 +136,161 @@ def _load_target_csv(path: str) -> dict:
     if not scores or "key" not in meta or "name" not in meta:
         return None
 
-    # Visual ring radii (for rendering only — NOT used for scoring)
-    rings_mm    = [d / 2.0 for d in diameters]
-    outer_dia   = float(meta.get("card_diameter_mm", diameters[-1]))
-    aiming_dia  = float(meta.get("aiming_mark_dia_mm", diameters[0]))
+    rings_mm = [d / 2.0 for d in diameters]
+    outer_dia = float(meta.get("card_diameter_mm", diameters[-1]))
+    aiming_dia = float(meta.get("aiming_mark_dia_mm", diameters[0]))
     unique_dias = list(dict.fromkeys(diameters))
-
     ring_labels = [str(int(s)) if s == int(s) else str(s) for s in scores]
-
-    # ── Multi-mark support ───────────────────────────────────────────────────
-    # mark_count and mark_spacing_mm are optional — single-mark targets omit them.
-    # mark_offsets: list of (x_mm, y_mm) centres relative to sheet centre.
-    # For a 5-mark quincunx at spacing s:
-    #   (-s,-s)  (+s,-s)     (Y+ = down, matching OpenCV)
-    #      (0, 0)
-    #   (-s,+s)  (+s,+s)
     mark_count = int(meta.get("mark_count", 1))
-    mark_offsets = None   # None = single mark at (0,0)
-    if mark_count > 1:
-        s = float(meta.get("mark_spacing_mm", 75.0))
-        if mark_count == 5:
-            h = s / 2      # half the square side = offset on each axis
-            mark_offsets = [
-                (-h, -h),   # top-left
-                (+h, -h),   # top-right
-                ( 0,  0),   # centre
-                (-h, +h),   # bottom-left
-                (+h, +h),   # bottom-right
-            ]
-        # Future: other mark_count values can be added here
 
     return {
-        "name":               meta["name"],
-        "key":                meta["key"],
-        "diameter_mm":        outer_dia,
-        "rings_mm":           rings_mm,
-        "ring_scores":        scores,
-        "gauging":            meta.get("gauging", "outward"),
-        "calibre_mm":         float(meta.get("calibre_mm", 4.5)),
-        "reference_dist_m":   float(meta.get("reference_dist_m", 10.0)),
+        "name": meta["name"],
+        "key": meta["key"],
+        "diameter_mm": outer_dia,
+        "rings_mm": rings_mm,
+        "ring_scores": scores,
+        "gauging": meta.get("gauging", "outward"),
+        "calibre_mm": float(meta.get("calibre_mm", 4.5)),
+        "reference_dist_m": float(meta.get("reference_dist_m", 10.0)),
         "aiming_mark_dia_mm": aiming_dia,
-        "outer_ring_dia_mm":  outer_dia,
-        "rings_dia_mm":       unique_dias,
-        "ring_labels":        ring_labels,
-        "a4_target_width_mm": float(meta.get("a4_target_width_mm",
-                                             min(outer_dia * 1.1, 170))),
-        "mark_count":         mark_count,
-        "mark_offsets":       mark_offsets,   # None for single-mark targets
-        "mark_spacing_mm":    float(meta.get("mark_spacing_mm", 0)),
+        "outer_ring_dia_mm": outer_dia,
+        "rings_dia_mm": unique_dias,
+        "ring_labels": ring_labels,
+        "a4_target_width_mm": float(
+            meta.get("a4_target_width_mm", min(outer_dia * 1.1, 170))),
+        "mark_count": mark_count,
+        "mark_offsets": _resolve_mark_offsets(meta),
+        "mark_spacing_mm": float(meta.get("mark_spacing_mm", 0)),
     }
 
-def _load_all_targets() -> dict:
-    """Load targets from the bundled and user dirs.
 
-    User files override bundled files when keys collide, so a shooter
-    can tweak a built-in target without losing the original.
-    """
-    targets = {}
-    for tdir in (_targets_dir(), _user_targets_dir()):
+# Backwards-compatible alias.
+_load_target_csv = load_target_csv
+
+
+def _iter_target_files(directories: Iterable[str]):
+    """Yield ``(directory, filename)`` for every CSV in the given dirs."""
+    for tdir in directories:
         if not os.path.isdir(tdir):
             continue
         for fname in sorted(os.listdir(tdir)):
-            if not fname.lower().endswith(".csv"):
-                continue
-            t = _load_target_csv(os.path.join(tdir, fname))
-            if t:
-                targets[t["key"]] = t
+            if fname.lower().endswith(".csv"):
+                yield tdir, fname
+
+
+def load_all_targets() -> dict:
+    """Merge target CSVs from the bundle and the user dir into a dict."""
+    targets: dict = {}
+    for tdir, fname in _iter_target_files(
+            (bundled_targets_dir(), writable_targets_dir())):
+        target = load_target_csv(os.path.join(tdir, fname))
+        if target:
+            targets[target["key"]] = target
     return targets
 
 
-TARGETS = _load_all_targets()
+_load_all_targets = load_all_targets
+
+TARGETS = load_all_targets()
 
 
-# ── Default runtime config ──────────────────────────────────────────────────
 DEFAULT_CONFIG = {
-    # ── Target & scoring ─────────────────────────────────────────────────────
-    "target_key":              "10m_air_rifle",
-    "real_range_m":            10.0,         # shooting distance (m)
-    "shot_circle_calibre_mm":  4.5,          # displayed shot hole diameter (mm)
-    "scoring_calibre_mm":      4.5,          # pellet diameter for scoring geometry (.177=4.5 .22=5.6)
-    "decimal_scoring":         False,        # ISSF decimal scoring mode
-    "ignore_misses":           False,        # discard shots scoring 0
+    # Target & scoring
+    "target_key": "10m_air_rifle",
+    "real_range_m": 10.0,
+    "shot_circle_calibre_mm": 4.5,
+    "scoring_calibre_mm": 4.5,
+    "decimal_scoring": False,
+    "ignore_misses": False,
 
-    # ── Camera ───────────────────────────────────────────────────────────────
-    "camera_index":    0,
-    "video_width":     640,
-    "video_height":    480,
-    "video_fps":       30,
-    "camera_rotation": 0,       # 0 / 90 / 180 / 270 degrees
-    "flip_image":      False,
-    "flip_mode":       -1,
-    "no_video_mode":   False,   # skip camera preview (faster on slow machines)
-    "use_clahe":       True,    # adaptive contrast enhancement for ArUco detection
-    "clahe_clip":      4.0,     # CLAHE clip limit (2=mild, 4=moderate, 8=aggressive)
-    "brightness_target": 128.0, # software gain target brightness (0-255, 128=mid)
-    "spike_velocity_mm":  25.0, # min mm/frame for spike candidate
-    "spike_reversal":     0.7,  # min reversal ratio to confirm spike (0-1)
+    # Camera
+    "camera_index": 0,
+    "video_width": 640,
+    "video_height": 480,
+    "video_fps": 30,
+    "camera_rotation": 0,
+    "flip_image": False,
+    "flip_mode": -1,
+    "no_video_mode": False,
+    "use_clahe": True,
+    "clahe_clip": 4.0,
+    "brightness_target": 128.0,
+    "spike_velocity_mm": 25.0,
+    "spike_reversal": 0.7,
 
-    # ── ArUco tracking ───────────────────────────────────────────────────────
-    "aruco_dict":       "DICT_4X4_50",
-    "aruco_marker_count": 4,        # number of ArUco markers: 4, 6, or 8
-    "camera_pixel_format": "Auto",  # Auto / MJPEG / YUY2
-    "aruco_marker_mm":  40.0,   # printed size of each ArUco marker (mm)
-    "aruco_margin_mm":  8.0,    # margin from sheet edge to marker corner (mm)
+    # ArUco tracking
+    "aruco_dict": "DICT_4X4_50",
+    "aruco_marker_count": 4,
+    "camera_pixel_format": "Auto",
+    "aruco_marker_mm": 40.0,
+    "aruco_margin_mm": 8.0,
 
-    # ── Smoothing ────────────────────────────────────────────────────────────
-    "smooth_mode":   "ema",     # "none" / "ema" / "savgol"
-    "smooth_alpha":  0.35,      # EMA alpha (0.05=heavy smooth, 0.8=light)
-    "smooth_window": 11,        # Savitzky-Golay window size (odd number)
-    "smooth_poly":   2,         # Savitzky-Golay polynomial degree
+    # Smoothing
+    "smooth_mode": "ema",
+    "smooth_alpha": 0.35,
+    "smooth_window": 11,
+    "smooth_poly": 2,
 
-    # ── Audio detection ──────────────────────────────────────────────────────
-    "audio_device_index":       None,
-    "audio_sample_rate":        44100,
-    "audio_trigger_threshold":  0.4,
-    "audio_transient_ratio":    6.0,
-    "audio_trigger_cooldown_ms":800,
-    "post_shot_cooldown_s":     2.0,   # ignore audio N seconds after a shot
+    # Audio detection
+    "audio_device_index": None,
+    "audio_sample_rate": 44100,
+    "audio_trigger_threshold": 0.4,
+    "audio_transient_ratio": 6.0,
+    "audio_trigger_cooldown_ms": 800,
+    "post_shot_cooldown_s": 2.0,
 
-    # ── Trace colours (hex, BGR-converted at render time) ────────────────────
-    "colour_trace_approach": "#3c3c3c",  # approach zone: dark grey
-    "colour_trace_hold":     "#28be50",  # early hold: green
-    "colour_trace_preshot":  "#f0d000",  # pre-shot window: yellow
-    "colour_trace_final":    "#e03020",  # final window: red
-    "colour_shot_fill":      "#5050ff",  # shot hole fill
-    "colour_acp":            "#ffc800",  # ACP marker
-    "colour_crosshair":      "#00dc64",  # live crosshair
-    "colour_mpi":            "#50b4ff",  # MPI cross
-    "colour_group":          "#6464ff",  # group circle
-    "colour_miss":           "#3c3cd0",  # miss X marker
+    # Trace and shot colours (hex; converted to BGR at render time)
+    "colour_trace_approach": "#3c3c3c",
+    "colour_trace_hold":     "#28be50",
+    "colour_trace_preshot":  "#f0d000",
+    "colour_trace_final":    "#e03020",
+    "colour_shot_fill":      "#5050ff",
+    "colour_acp":            "#ffc800",
+    "colour_crosshair":      "#00dc64",
+    "colour_mpi":            "#50b4ff",
+    "colour_group":          "#6464ff",
+    "colour_miss":           "#3c3cd0",
 
-    # ── Trace behaviour ──────────────────────────────────────────────────────
-    "trace_width":            1,
-    "trace_preshot_s":        1.0,   # seconds before shot: trace turns yellow
-    "trace_final_s":          0.2,   # seconds before shot: trace turns red
-    "fading_trace_duration_s":2.0,   # how long post-shot trace lingers
-    "acp_fraction":           0.40,  # fraction of hold used for ACP
-    "approach_zone_factor":   2.0,   # approach zone = scoring_radius × this
+    # Trace behaviour
+    "trace_width": 1,
+    "trace_preshot_s": 1.0,
+    "trace_final_s": 0.2,
+    "fading_trace_duration_s": 2.0,
+    "acp_fraction": 0.40,
+    "approach_zone_factor": 2.0,
 
-    # ── Zero offset (persistent across restarts) ─────────────────────────────
+    # Persisted zero offset
     "zero_offset_x": 0.0,
     "zero_offset_y": 0.0,
 
-    # ── Session & files ──────────────────────────────────────────────────────
-    "session_name":       "Session",
-    "shooter_name":       "",
-    "shots_per_series":   10,
-    "save_directory":     "",    # empty = sessions/ folder in user data dir
+    # Session & files
+    "session_name": "Session",
+    "shooter_name": "",
+    "shots_per_series": 10,
+    "save_directory": "",
 }
 
 
-def load_config():
-    """Load config. Returns (cfg, is_first_run)."""
+def load_config() -> Tuple[dict, bool]:
+    """Load the persisted config or return defaults.
+
+    Returns:
+        ``(cfg, is_first_run)``. ``is_first_run`` is true when no config
+        file exists or the existing one could not be parsed.
+    """
     cfg = DEFAULT_CONFIG.copy()
-    first_run = not os.path.exists(CONFIG_FILE)
-    if not first_run:
-        try:
-            with open(CONFIG_FILE, "r") as f:
-                saved = json.load(f)
-            cfg.update(saved)
-        except Exception:
-            first_run = True  # corrupt config treated as first run
-    return cfg, first_run
+    if not os.path.exists(CONFIG_FILE):
+        return cfg, True
+    try:
+        with open(CONFIG_FILE, "r") as f:
+            cfg.update(json.load(f))
+        return cfg, False
+    except Exception:
+        return cfg, True
 
 
-def save_config(cfg: dict):
+def save_config(cfg: dict) -> None:
+    """Write the config to the user data dir, ignoring write errors."""
     try:
         os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
         with open(CONFIG_FILE, "w") as f:

--- a/core/marker_sheet.py
+++ b/core/marker_sheet.py
@@ -252,14 +252,29 @@ def generate_marker_sheet(
          f"  Markers: {marker_count}  |  "
          f"Aiming mark: {aiming_dia_scaled:.1f}mm  |  "
          f"Card: {outer_dia_scaled:.1f}mm  |  Markers: {marker:.0f}mm"),
-        "Print at 100% on A4 — NO fit-to-page scaling.",
+        "Print at 100% on A4 - NO fit-to-page scaling.",
         "Verify printed aiming mark diameter with ruler before use.",
     ])
 
-    cv2.imwrite(output_path, img)
+    _save_with_dpi(output_path, img, DPI)
     print(f"[MarkerSheet] Saved: {output_path}  (scale={scale_pct*100:.0f}%, "
           f"aiming mark={aiming_dia_scaled:.1f}mm)")
     return output_path
+
+
+def _save_with_dpi(path: str, img_bgr: np.ndarray, dpi: int) -> None:
+    """Write a PNG/JPEG with the physical print resolution embedded.
+
+    ``cv2.imwrite`` produces a bare bitmap with no DPI tag, so when
+    the file is opened by a print pipeline the page size defaults to
+    whatever DPI the printer assumes (often 72 or 96), producing a
+    sheet several times larger than A4. Round-tripping through PIL
+    lets us write the standard ``pHYs`` chunk for PNG and the JFIF
+    density fields for JPEG.
+    """
+    from PIL import Image
+    rgb = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB)
+    Image.fromarray(rgb).save(path, dpi=(dpi, dpi))
 
 
 if __name__ == "__main__":

--- a/core/marker_sheet.py
+++ b/core/marker_sheet.py
@@ -1,202 +1,265 @@
-"""
-core/marker_sheet.py
-Generates a printable A4 marker sheet with:
-  - Four ArUco corner markers
-  - A distance-scaled aiming mark (black) in the centre
-  - Optional scoring ring guides
+"""Generator for the printable A4 ArUco marker sheet.
 
-The aiming mark (the black) is scaled as a percentage of its reference size
-at the nominal distance. E.g. 10m air rifle black = 30.5mm dia at 10m;
-at 5m it should be 15.25mm dia (50% scale).
+The sheet carries the configured number of ArUco markers around its
+edges and one or more aiming marks in the centre. Each mark scales
+linearly with the print distance::
 
-Scaling formula:
-    aiming_mark_dia_mm = reference_dia_mm * (print_distance_m / reference_distance_m)
+    aiming_mark_dia_mm = reference_dia_mm * (print_distance_m
+                                              / reference_distance_m)
+
+Printing at 100% on A4 (no fit-to-page scaling) is required.
 """
+
+from __future__ import annotations
+
+import os
+from typing import Optional, Tuple
 
 import cv2
 import numpy as np
-import os
 
-# A4 at 300 DPI
-A4_W_MM  = 210.0
-A4_H_MM  = 297.0
-DPI      = 300
-A4_W_PX  = 2480
-A4_H_PX  = 3508
+
+# A4 at 300 DPI.
+A4_W_MM = 210.0
+A4_H_MM = 297.0
+DPI = 300
+A4_W_PX = 2480
+A4_H_PX = 3508
 MM_TO_PX = DPI / 25.4
 
-MARGIN_MM  = 8.0
-MARKER_MM  = 40.0
+DEFAULT_MARGIN_MM = 8.0
+DEFAULT_MARKER_MM = 40.0
 
 
-# ── Target aiming mark definitions ───────────────────────────────────────────
-# Each entry:
-#   name              : display name
-#   reference_dist_m  : nominal distance this target is designed for
-#   aiming_mark_dia_mm: diameter of the black aiming mark at reference distance
-#   outer_ring_dia_mm : diameter of the full scoring card / outer ring
-#   rings_dia_mm      : list of ring diameters (innermost first) for guide circles
-#   ring_labels       : score labels for each ring
-
-def _get_aiming_marks():
-    """Build the aiming marks dict from the loaded TARGETS."""
+def _build_aiming_marks() -> dict:
+    """Build the aiming-mark dict from the loaded target catalogue."""
     from core.config import TARGETS
+
     marks = {}
     for key, t in TARGETS.items():
         marks[key] = {
-            "name":               t["name"],
-            "reference_dist_m":   t.get("reference_dist_m", 10.0),
-            "aiming_mark_dia_mm": t.get("aiming_mark_dia_mm", t["diameter_mm"] * 0.67),
-            "outer_ring_dia_mm":  t["diameter_mm"],
-            "rings_dia_mm":       t.get("rings_dia_mm", [d * 2 for d in t["rings_mm"]]),
-            "ring_labels":        t.get("ring_labels",
-                                        [str(int(s)) if s == int(s) else str(s)
-                                         for s in t["ring_scores"]]),
-            "mark_offsets":       t.get("mark_offsets"),   # None for single-mark
+            "name": t["name"],
+            "reference_dist_m": t.get("reference_dist_m", 10.0),
+            "aiming_mark_dia_mm": t.get(
+                "aiming_mark_dia_mm", t["diameter_mm"] * 0.67),
+            "outer_ring_dia_mm": t["diameter_mm"],
+            "rings_dia_mm": t.get(
+                "rings_dia_mm", [d * 2 for d in t["rings_mm"]]),
+            "ring_labels": t.get(
+                "ring_labels",
+                [str(int(s)) if s == int(s) else str(s)
+                 for s in t["ring_scores"]],
+            ),
+            "mark_offsets": t.get("mark_offsets"),
         }
     return marks
 
-# Computed once at import — will include any user-added CSVs
-AIMING_MARKS = _get_aiming_marks()
+
+# Backwards-compatible alias used by the UI module.
+_get_aiming_marks = _build_aiming_marks
 
 
-def mm(v: float) -> int:
-    return int(v * MM_TO_PX)
+# Computed once at import time. Includes any user-added target CSVs.
+AIMING_MARKS = _build_aiming_marks()
+
+
+def mm(value: float) -> int:
+    """Convert millimetres to image pixels at the sheet DPI."""
+    return int(value * MM_TO_PX)
+
+
+def _marker_positions(
+    marker_count: int, marker_px: int, margin_px: int,
+) -> dict:
+    """Pixel positions for each marker ID at the chosen layout."""
+    positions = {
+        0: (margin_px, margin_px),
+        1: (A4_W_PX - margin_px - marker_px, margin_px),
+        2: (A4_W_PX - margin_px - marker_px, A4_H_PX - margin_px - marker_px),
+        3: (margin_px, A4_H_PX - margin_px - marker_px),
+    }
+    if marker_count >= 6:
+        positions[4] = (margin_px, A4_H_PX // 2 - marker_px // 2)
+        positions[5] = (A4_W_PX - margin_px - marker_px,
+                        A4_H_PX // 2 - marker_px // 2)
+    if marker_count >= 8:
+        positions[6] = (A4_W_PX // 2 - marker_px // 2, margin_px)
+        positions[7] = (A4_W_PX // 2 - marker_px // 2,
+                        A4_H_PX - margin_px - marker_px)
+    return positions
+
+
+_MARKER_LABELS = {
+    0: "TL(0)", 1: "TR(1)", 2: "BR(2)", 3: "BL(3)",
+    4: "LM(4)", 5: "RM(5)", 6: "TM(6)", 7: "BM(7)",
+}
+
+
+def _draw_markers(
+    img: np.ndarray, aruco_dict, positions: dict, marker_px: int,
+) -> None:
+    """Render each ArUco marker at its position with a label underneath."""
+    border = 4
+    for mid, (x, y) in positions.items():
+        marker_img = cv2.aruco.generateImageMarker(aruco_dict, mid, marker_px)
+        bordered = np.full(
+            (marker_px + 2 * border, marker_px + 2 * border),
+            255, dtype=np.uint8,
+        )
+        bordered[border:border + marker_px, border:border + marker_px] = (
+            marker_img)
+        h, w = bordered.shape
+        img[y - border:y - border + h, x - border:x - border + w] = bordered
+
+        label_x = x if mid in (0, 3) else x - mm(8)
+        label_y = y + marker_px + mm(5) if mid in (0, 1) else y - mm(2)
+        cv2.putText(img, _MARKER_LABELS[mid], (label_x, label_y),
+                    cv2.FONT_HERSHEY_SIMPLEX, 1.0, 0, 2)
+
+
+def _draw_dashed_circle(
+    img: np.ndarray, cx: int, cy: int, radius: int,
+    shade: int = 150, n_dashes: int = 48,
+) -> None:
+    """Draw a dashed circle in greyscale at the given centre and radius."""
+    for i in range(0, n_dashes, 2):
+        a1 = 2 * np.pi * i / n_dashes
+        a2 = 2 * np.pi * (i + 1) / n_dashes
+        points = [
+            (int(cx + radius * np.cos(a)), int(cy + radius * np.sin(a)))
+            for a in np.linspace(a1, a2, 6)
+        ]
+        for p1, p2 in zip(points, points[1:]):
+            cv2.line(img, p1, p2, shade, 2)
+
+
+def _draw_aiming_mark(
+    img: np.ndarray, cx: int, cy: int, mark_cfg: dict,
+    scale_pct: float, outer_dia_scaled: float, aiming_dia_scaled: float,
+    show_ring_guides: bool, show_labels: bool,
+) -> None:
+    """Draw rings, outer boundary, black aiming bull and centre cross."""
+    if show_ring_guides:
+        for i, ring_dia in enumerate(mark_cfg["rings_dia_mm"]):
+            r_px = mm(ring_dia / 2 * scale_pct)
+            if r_px < 4:
+                continue
+            _draw_dashed_circle(img, cx, cy, r_px, shade=160, n_dashes=48)
+            if not show_labels:
+                continue
+            labels = mark_cfg["ring_labels"]
+            label = labels[i] if i < len(labels) else ""
+            if label:
+                cv2.putText(img, label, (cx + r_px + mm(1), cy + mm(1)),
+                            cv2.FONT_HERSHEY_SIMPLEX, 0.7, 120, 1)
+
+    outer_r_px = mm(outer_dia_scaled / 2)
+    if outer_r_px > 4:
+        cv2.circle(img, (cx, cy), outer_r_px, 100, 2)
+
+    aim_r_px = mm(aiming_dia_scaled / 2)
+    if aim_r_px > 2:
+        cv2.circle(img, (cx, cy), aim_r_px, 0, -1)
+    else:
+        cv2.circle(img, (cx, cy), max(3, mm(0.5)), 0, -1)
+
+    cross = max(mm(2), aim_r_px // 4)
+    cv2.line(img, (cx - cross, cy), (cx + cross, cy), 255, 2)
+    cv2.line(img, (cx, cy - cross), (cx, cy + cross), 255, 2)
+
+
+def _aiming_mark_centres(
+    mark_offsets: Optional[list], scale_pct: float,
+) -> list:
+    """Pixel centres for each aiming mark on the sheet."""
+    cx, cy = A4_W_PX // 2, A4_H_PX // 2
+    if not mark_offsets:
+        return [(cx, cy)]
+    return [
+        (cx + mm(mx * scale_pct), cy + mm(my * scale_pct))
+        for mx, my in mark_offsets
+    ]
+
+
+def _draw_instructions(
+    img: np.ndarray, lines: list,
+) -> None:
+    """Render the print instructions strip at the foot of the sheet."""
+    for i, line in enumerate(lines):
+        cv2.putText(img, line,
+                    (mm(10), A4_H_PX - mm(36) + i * mm(9)),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.85, 60, 1)
 
 
 def generate_marker_sheet(
     output_path: str = "aruco_sheet.png",
     target_key: str = "10m_air_rifle",
-    print_distance_m: float = None,
+    print_distance_m: Optional[float] = None,
     show_ring_guides: bool = True,
     aruco_dict_name: str = "DICT_4X4_50",
-    marker_size_mm: float = None,         # None = use MARKER_MM default (40mm)
-    margin_mm: float = None,              # None = use MARGIN_MM default (8mm)
-    marker_count: int = 4,               # 4 / 6 / 8 markers on the sheet
+    marker_size_mm: Optional[float] = None,
+    margin_mm: Optional[float] = None,
+    marker_count: int = 4,
 ) -> str:
-    """
-    Generate and save the ArUco marker sheet.
+    """Generate the marker sheet PNG and return its path.
 
-    The aiming mark is scaled proportionally:
-        scale = print_distance_m / reference_distance_m
-
-    So at half the reference distance, everything is half the size.
+    Args:
+        output_path: Destination PNG path.
+        target_key: Key into the target catalogue.
+        print_distance_m: Distance the sheet will be printed for. Defaults
+            to the target's reference distance, i.e. 100% scale.
+        show_ring_guides: Draw dashed scoring-ring guides around the bull.
+        aruco_dict_name: ``cv2.aruco`` dictionary name.
+        marker_size_mm: Printed marker size. Defaults to ``DEFAULT_MARKER_MM``.
+        margin_mm: Distance from sheet edge to marker. Defaults to
+            ``DEFAULT_MARGIN_MM``.
+        marker_count: Number of markers on the sheet (4, 6 or 8).
     """
     mark_cfg = AIMING_MARKS.get(target_key, AIMING_MARKS["10m_air_rifle"])
-    ref_dist  = mark_cfg["reference_dist_m"]
-    dist      = print_distance_m if print_distance_m else ref_dist
-    scale_pct = dist / ref_dist          # e.g. 0.5 for 5m with 10m reference
+    ref_dist = mark_cfg["reference_dist_m"]
+    distance = print_distance_m if print_distance_m else ref_dist
+    scale_pct = distance / ref_dist
 
     aiming_dia_scaled = mark_cfg["aiming_mark_dia_mm"] * scale_pct
-    outer_dia_scaled  = mark_cfg["outer_ring_dia_mm"]  * scale_pct
+    outer_dia_scaled = mark_cfg["outer_ring_dia_mm"] * scale_pct
+    marker = marker_size_mm if marker_size_mm else DEFAULT_MARKER_MM
+    margin = margin_mm if margin_mm else DEFAULT_MARGIN_MM
 
     img = np.full((A4_H_PX, A4_W_PX), 255, dtype=np.uint8)
 
-    dict_id    = getattr(cv2.aruco, aruco_dict_name, cv2.aruco.DICT_4X4_50)
+    dict_id = getattr(cv2.aruco, aruco_dict_name, cv2.aruco.DICT_4X4_50)
     aruco_dict = cv2.aruco.getPredefinedDictionary(dict_id)
-    _marker = marker_size_mm if marker_size_mm else MARKER_MM
-    _margin = margin_mm if margin_mm else MARGIN_MM
-    marker_px  = mm(_marker)
-    margin_px  = mm(_margin)
+    marker_px = mm(marker)
+    margin_px = mm(margin)
 
-    # ── Draw ArUco markers ────────────────────────────────────────────────────
-    positions = {
-        0: (margin_px,                        margin_px),
-        1: (A4_W_PX - margin_px - marker_px,  margin_px),
-        2: (A4_W_PX - margin_px - marker_px,  A4_H_PX - margin_px - marker_px),
-        3: (margin_px,                        A4_H_PX - margin_px - marker_px),
-    }
-    # Extended positions for 6 and 8 marker layouts
-    if marker_count >= 6:
-        positions[4] = (margin_px, A4_H_PX // 2 - marker_px // 2)
-        positions[5] = (A4_W_PX - margin_px - marker_px, A4_H_PX // 2 - marker_px // 2)
-    if marker_count >= 8:
-        positions[6] = (A4_W_PX // 2 - marker_px // 2, margin_px)
-        positions[7] = (A4_W_PX // 2 - marker_px // 2, A4_H_PX - margin_px - marker_px)
+    _draw_markers(
+        img, aruco_dict,
+        _marker_positions(marker_count, marker_px, margin_px),
+        marker_px,
+    )
 
-    labels = {0: "TL(0)", 1: "TR(1)", 2: "BR(2)", 3: "BL(3)",
-              4: "LM(4)", 5: "RM(5)", 6: "TM(6)", 7: "BM(7)"}
-    for mid, (x, y) in positions.items():
-        mimg = cv2.aruco.generateImageMarker(aruco_dict, mid, marker_px)
-        b = 4
-        bordered = np.full((marker_px + 2*b, marker_px + 2*b), 255, dtype=np.uint8)
-        bordered[b:b+marker_px, b:b+marker_px] = mimg
-        mh, mw = bordered.shape
-        img[y-b:y-b+mh, x-b:x-b+mw] = bordered
-        lx = x if mid in (0, 3) else x - mm(8)
-        ly = y + marker_px + mm(5) if mid in (0, 1) else y - mm(2)
-        cv2.putText(img, labels[mid], (lx, ly), cv2.FONT_HERSHEY_SIMPLEX, 1.0, 0, 2)
+    centres = _aiming_mark_centres(mark_cfg.get("mark_offsets"), scale_pct)
+    for i, (cx, cy) in enumerate(centres):
+        _draw_aiming_mark(
+            img, cx, cy, mark_cfg, scale_pct,
+            outer_dia_scaled, aiming_dia_scaled,
+            show_ring_guides, show_labels=(i == 0),
+        )
 
-    # ── Draw aiming mark(s) ───────────────────────────────────────────────────
-    cx, cy = A4_W_PX // 2, A4_H_PX // 2
-
-    # For multi-mark targets, compute each mark's pixel position.
-    # mark_offsets are in mm from sheet centre; scale_pct shrinks them for
-    # closer distances just like the rings.
-    mark_offsets = mark_cfg.get("mark_offsets")   # None for single-mark targets
-    if mark_offsets:
-        centres_px = [
-            (cx + mm(mx * scale_pct), cy + mm(my * scale_pct))
-            for mx, my in mark_offsets
-        ]
-    else:
-        centres_px = [(cx, cy)]
-
-    def _draw_one_mark(ocx, ocy, show_labels):
-        """Draw rings, outer boundary, black bull, and cross at (ocx, ocy)."""
-        if show_ring_guides:
-            for i, ring_dia in enumerate(mark_cfg["rings_dia_mm"]):
-                r_px = mm(ring_dia / 2 * scale_pct)
-                if r_px < 4:
-                    continue
-                _draw_dashed_circle(img, ocx, ocy, r_px, shade=160, n_dashes=48)
-                if show_labels:
-                    lbl = mark_cfg["ring_labels"][i] if i < len(mark_cfg["ring_labels"]) else ""
-                    if lbl:
-                        cv2.putText(img, lbl, (ocx + r_px + mm(1), ocy + mm(1)),
-                                    cv2.FONT_HERSHEY_SIMPLEX, 0.7, 120, 1)
-        outer_r_px = mm(outer_dia_scaled / 2)
-        if outer_r_px > 4:
-            cv2.circle(img, (ocx, ocy), outer_r_px, 100, 2)
-        aim_r_px = mm(aiming_dia_scaled / 2)
-        if aim_r_px > 2:
-            cv2.circle(img, (ocx, ocy), aim_r_px, 0, -1)
-        else:
-            cv2.circle(img, (ocx, ocy), max(3, mm(0.5)), 0, -1)
-        cross = max(mm(2), aim_r_px // 4)
-        cv2.line(img, (ocx - cross, ocy), (ocx + cross, ocy), 255, 2)
-        cv2.line(img, (ocx, ocy - cross), (ocx, ocy + cross), 255, 2)
-
-    for i, (ocx, ocy) in enumerate(centres_px):
-        _draw_one_mark(ocx, ocy, show_labels=(i == 0))
-
-    # ── Print instructions ────────────────────────────────────────────────────
-    instr_lines = [
+    _draw_instructions(img, [
         f"SPLATT2  —  {mark_cfg['name']}",
-        f"Print distance: {dist:.1f}m  |  Scale: {scale_pct*100:.0f}%  |  Markers: {marker_count}  |  "
-        f"Aiming mark: {aiming_dia_scaled:.1f}mm  |  Card: {outer_dia_scaled:.1f}mm  |  Markers: {_marker:.0f}mm",
+        (f"Print distance: {distance:.1f}m  |  Scale: {scale_pct*100:.0f}%  |"
+         f"  Markers: {marker_count}  |  "
+         f"Aiming mark: {aiming_dia_scaled:.1f}mm  |  "
+         f"Card: {outer_dia_scaled:.1f}mm  |  Markers: {marker:.0f}mm"),
         "Print at 100% on A4 — NO fit-to-page scaling.",
         "Verify printed aiming mark diameter with ruler before use.",
-    ]
-    for i, line in enumerate(instr_lines):
-        cv2.putText(img, line, (mm(10), A4_H_PX - mm(36) + i * mm(9)),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.85, 60, 1)
+    ])
 
     cv2.imwrite(output_path, img)
-    print(f"[MarkerSheet] Saved: {output_path}  (scale={scale_pct*100:.0f}%,"
-          f" aiming mark={aiming_dia_scaled:.1f}mm)")
+    print(f"[MarkerSheet] Saved: {output_path}  (scale={scale_pct*100:.0f}%, "
+          f"aiming mark={aiming_dia_scaled:.1f}mm)")
     return output_path
-
-
-def _draw_dashed_circle(img, cx, cy, r, shade=150, n_dashes=48):
-    for i in range(n_dashes):
-        if i % 2 == 0:
-            a1 = 2 * np.pi * i / n_dashes
-            a2 = 2 * np.pi * (i + 1) / n_dashes
-            pts = [(int(cx + r * np.cos(a)), int(cy + r * np.sin(a)))
-                   for a in np.linspace(a1, a2, 6)]
-            for k in range(len(pts) - 1):
-                cv2.line(img, pts[k], pts[k+1], shade, 2)
 
 
 if __name__ == "__main__":

--- a/core/paths.py
+++ b/core/paths.py
@@ -1,9 +1,18 @@
-"""Path resolution for source, PyInstaller and Nuitka builds.
+"""Filesystem paths for source, PyInstaller and Nuitka builds.
 
-`resource_path` returns bundled read-only assets (targets/ etc).
-`user_data_dir` and friends return writable per-user paths following
-OS conventions. Set SPLATT2_USER_DIR to override the user dir.
+``resource_path`` returns paths to bundled read-only assets (target CSVs,
+icons, etc). ``user_data_dir`` and its callers return writable per-user
+locations that follow OS conventions:
+
+- macOS: ``~/Library/Application Support/Splatt2``
+- Windows: ``%APPDATA%/Splatt2``
+- Linux: ``$XDG_DATA_HOME/Splatt2`` or ``~/.local/share/Splatt2``
+
+Set ``SPLATT2_USER_DIR`` to override the user directory entirely (useful
+for portable installs and tests).
 """
+
+from __future__ import annotations
 
 import os
 import sys
@@ -14,15 +23,15 @@ APP_NAME = "Splatt2"
 
 def is_frozen() -> bool:
     """True when running from a PyInstaller or Nuitka bundle."""
-    return (getattr(sys, "frozen", False)
-            or hasattr(sys, "_MEIPASS")
-            or "__compiled__" in globals())
+    return (
+        getattr(sys, "frozen", False)
+        or hasattr(sys, "_MEIPASS")
+        or "__compiled__" in globals()
+    )
 
 
 def _bundle_root() -> Path:
-    # PyInstaller sets _MEIPASS to the bundle root (extracted temp dir
-    # for onefile, _internal/ for onedir). Source and Nuitka layouts
-    # both have core/ one level below the project root.
+    """Root of the running bundle, or the project root when run from source."""
     meipass = getattr(sys, "_MEIPASS", None)
     if meipass:
         return Path(meipass)
@@ -57,25 +66,27 @@ def user_data_dir() -> Path:
 
 
 def config_path() -> Path:
+    """Path to the user's persisted config file."""
     return user_data_dir() / "splatt2_config.json"
 
 
 def crash_log_path() -> Path:
+    """Path to the user's crash log file."""
     return user_data_dir() / "splatt2_crash.log"
 
 
 def sessions_dir() -> Path:
-    """Default sessions/ folder, created on first access."""
+    """Default ``sessions/`` folder, created on first access."""
     p = user_data_dir() / "sessions"
     p.mkdir(parents=True, exist_ok=True)
     return p
 
 
 def user_targets_dir() -> Path:
-    """User-writable targets/ folder, created on first access.
+    """User-writable ``targets/`` folder, created on first access.
 
     Bundled targets remain read-only seeds; targets created or edited
-    in-app are written here and merged at load time.
+    in-app are written here and merged with the seeds at load time.
     """
     p = user_data_dir() / "targets"
     p.mkdir(parents=True, exist_ok=True)

--- a/core/paths.py
+++ b/core/paths.py
@@ -69,3 +69,14 @@ def sessions_dir() -> Path:
     p = user_data_dir() / "sessions"
     p.mkdir(parents=True, exist_ok=True)
     return p
+
+
+def user_targets_dir() -> Path:
+    """User-writable targets/ folder, created on first access.
+
+    Bundled targets remain read-only seeds; targets created or edited
+    in-app are written here and merged at load time.
+    """
+    p = user_data_dir() / "targets"
+    p.mkdir(parents=True, exist_ok=True)
+    return p

--- a/core/paths.py
+++ b/core/paths.py
@@ -1,0 +1,71 @@
+"""Path resolution for source, PyInstaller and Nuitka builds.
+
+`resource_path` returns bundled read-only assets (targets/ etc).
+`user_data_dir` and friends return writable per-user paths following
+OS conventions. Set SPLATT2_USER_DIR to override the user dir.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+APP_NAME = "Splatt2"
+
+
+def is_frozen() -> bool:
+    """True when running from a PyInstaller or Nuitka bundle."""
+    return (getattr(sys, "frozen", False)
+            or hasattr(sys, "_MEIPASS")
+            or "__compiled__" in globals())
+
+
+def _bundle_root() -> Path:
+    # PyInstaller sets _MEIPASS to the bundle root (extracted temp dir
+    # for onefile, _internal/ for onedir). Source and Nuitka layouts
+    # both have core/ one level below the project root.
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        return Path(meipass)
+    return Path(__file__).resolve().parent.parent
+
+
+def resource_path(*parts: str) -> Path:
+    """Path to a bundled read-only asset, e.g. ``resource_path('targets')``."""
+    return _bundle_root().joinpath(*parts)
+
+
+def _platform_user_dir() -> Path:
+    override = os.environ.get("SPLATT2_USER_DIR")
+    if override:
+        return Path(override).expanduser()
+
+    if sys.platform.startswith("win"):
+        base = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        return Path(base) / APP_NAME
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / APP_NAME
+
+    base = os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local" / "share")
+    return Path(base) / APP_NAME
+
+
+def user_data_dir() -> Path:
+    """Per-user writable directory, created on first access."""
+    p = _platform_user_dir()
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def config_path() -> Path:
+    return user_data_dir() / "splatt2_config.json"
+
+
+def crash_log_path() -> Path:
+    return user_data_dir() / "splatt2_crash.log"
+
+
+def sessions_dir() -> Path:
+    """Default sessions/ folder, created on first access."""
+    p = user_data_dir() / "sessions"
+    p.mkdir(parents=True, exist_ok=True)
+    return p

--- a/core/session.py
+++ b/core/session.py
@@ -30,6 +30,10 @@ DEFAULT_SCORING_RADIUS_MM = 22.75
 ZONE_APPROACH = "approach"
 ZONE_ON_TARGET = "on_target"
 
+# Compact integer codes for trace zones in saved JSON archives.
+_ZONE_TO_CODE = {ZONE_ON_TARGET: 0, ZONE_APPROACH: 1}
+_CODE_TO_ZONE = {0: ZONE_ON_TARGET, 1: ZONE_APPROACH}
+
 
 @dataclass
 class TracePoint:
@@ -636,9 +640,16 @@ class Session:
         return time.time() - self.start_time
 
     def save_json(self, path: str) -> None:
-        """Write a full session archive (including trace points) as JSON."""
+        """Write a full session archive (including trace points) as JSON.
+
+        Trace points are stored as flat ``[t, x, y, z]`` lists rather
+        than per-key dicts. With ~100 points per shot and hundreds of
+        shots per session, this cuts the file size and parse time by
+        roughly 4x compared to the verbose dict shape.
+        """
         os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
         data = {
+            "schema": 2,
             "name": self.name,
             "start_time": self.start_time,
             "end_time": time.time(),
@@ -655,8 +666,8 @@ class Session:
                     "aim_centrepoint": (
                         list(s.aim_centrepoint) if s.aim_centrepoint else None),
                     "trace": [
-                        {"t": p.timestamp, "x": p.aim_mm[0],
-                         "y": p.aim_mm[1], "z": p.zone}
+                        [p.timestamp, p.aim_mm[0], p.aim_mm[1],
+                         _ZONE_TO_CODE.get(p.zone, 0)]
                         for p in (s.trace.points if s.trace else [])
                     ],
                 }
@@ -664,7 +675,7 @@ class Session:
             ],
         }
         with open(path, "w") as f:
-            json.dump(data, f, indent=2)
+            json.dump(data, f)
 
     def save_csv(self, path: str) -> None:
         """Summary CSV with one row per shot and no trace points."""
@@ -877,16 +888,25 @@ def load_session_history(save_dir: str) -> dict:
 
 
 def reconstruct_shot_traces(session_data: dict) -> List[ShotTrace]:
-    """Rebuild :class:`ShotTrace` objects from a saved JSON session."""
+    """Rebuild :class:`ShotTrace` objects from a saved JSON session.
+
+    Accepts both the legacy per-point dict shape (``{"t":..., "x":...,
+    "y":..., "z":...}``) and the compact list shape
+    (``[t, x, y, zone_code]``).
+    """
     traces: List[ShotTrace] = []
     for s in session_data.get("shots", []):
         trace = ShotTrace()
+        points = trace.points
         for pt in s.get("trace", []):
-            trace.points.append(TracePoint(
-                timestamp=pt["t"],
-                aim_mm=(pt["x"], pt["y"]),
-                zone=pt.get("z", ZONE_ON_TARGET),
-            ))
+            if isinstance(pt, list):
+                t, x, y = pt[0], pt[1], pt[2]
+                zone = _CODE_TO_ZONE.get(pt[3], ZONE_ON_TARGET) \
+                    if len(pt) > 3 else ZONE_ON_TARGET
+            else:
+                t, x, y = pt["t"], pt["x"], pt["y"]
+                zone = pt.get("z", ZONE_ON_TARGET)
+            points.append(TracePoint(timestamp=t, aim_mm=(x, y), zone=zone))
         trace.fired_time = s.get("timestamp")
         trace.state = "fired"
         traces.append(trace)

--- a/core/session.py
+++ b/core/session.py
@@ -1,79 +1,55 @@
-"""
-core/session.py
+"""Shot data, trace recording and per-series file I/O.
 
-Key design decisions in this version:
-
-TRACE ZONES
------------
-Every aim position is recorded regardless of whether it's on-target,
-as long as it's within the "approach zone" (2× the scoring radius).
-This gives you the full picture of the shot approach.
-
-Each TracePoint carries an `on_target` flag so the renderer can colour
-approach points differently from hold points.
-
-    approach_radius_mm = scoring_radius_mm * 2.0
-    on_target_radius_mm = scoring_radius_mm (outer ring)
-
-FALSE-POSITIVE REJECTION
-------------------------
-A shot is only registered if aim_mm is within valid_shot_radius_mm
-(same as approach_radius_mm = 2× scoring radius). Any audio trigger
-while the camera is pointing well outside the target is discarded.
-
-LIVE SESSION FILE
------------------
-When start_series() is called, a CSV file is opened immediately.
-Every shot is appended as a line the moment it fires — no data is
-lost even if the app crashes. The file is named:
-    session_YYYYMMDD_HHMMSS_<name>.csv
-
-FADING TRACE FIX
-----------------
-fading_trace_display_start is set at the moment get_fading_trace()
-is first called after a shot, not when record_shot() runs. This means
-the 2-second window starts from when the UI actually sees it.
+A :class:`Session` owns the active aim trace, the list of recorded
+:class:`Shot` objects, the live CSV writer, and statistics (mean radius,
+extreme spread, CEP, MPI). Shots fired while the aim is well outside
+the target are rejected as false positives. Shots fired retroactively
+against a known timestamp are interpolated against the trace history so
+audio-detection latency does not skew the recorded position.
 """
 
-import os
+from __future__ import annotations
+
 import csv
 import json
-import time
 import math
+import os
+import time
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
+
 import numpy as np
 
 
-# ── Zone constants ────────────────────────────────────────────────────────────
-APPROACH_ZONE_FACTOR = 2.0    # approach zone = scoring_radius * this
-DEFAULT_SCORING_RADIUS_MM = 22.75   # 10m ISSF outer ring radius
+APPROACH_ZONE_FACTOR = 2.0
+"""Approach zone radius = scoring radius × this factor."""
 
-# Trace point zone labels
-ZONE_APPROACH  = "approach"   # outside scoring rings but within approach zone
-ZONE_ON_TARGET = "on_target"  # inside scoring rings
+DEFAULT_SCORING_RADIUS_MM = 22.75
+"""Outer ring radius for the 10 m ISSF target."""
+
+ZONE_APPROACH = "approach"
+ZONE_ON_TARGET = "on_target"
 
 
 @dataclass
 class TracePoint:
+    """A single sampled aim position with a zone classification."""
     timestamp: float
     aim_mm: Tuple[float, float]
-    zone: str = ZONE_ON_TARGET   # ZONE_APPROACH or ZONE_ON_TARGET
+    zone: str = ZONE_ON_TARGET
 
 
 @dataclass
 class ShotTrace:
-    """Complete trace for one shot — approach + hold + fire."""
+    """The full pre-shot trace plus the firing event for one shot."""
+
     points: List[TracePoint] = field(default_factory=list)
     fired_time: Optional[float] = None
     state: str = "active"
-    # Pre-computed colours — one entry per point, updated at append time.
-    # Avoids recalculating colour_for_point() for every point on every frame.
-    cached_colours: List[Tuple[int,int,int]] = field(default_factory=list)
-    # Renderer params used for the cache — stored so we can detect changes
+    # Pre-computed BGR colours (one per point) refreshed by the renderer.
+    cached_colours: List[Tuple[int, int, int]] = field(default_factory=list)
+    # Renderer params last used to populate ``cached_colours``.
     _cache_params: Optional[tuple] = field(default=None, repr=False)
-
-    # ── Accessors ─────────────────────────────────────────────────────────────
 
     @property
     def on_target_points(self) -> List[TracePoint]:
@@ -94,20 +70,22 @@ class ShotTrace:
             return 0.0
         return self.points[-1].timestamp - self.points[0].timestamp
 
-    def aim_centrepoint(self, fraction: float = 0.40) -> Optional[Tuple[float, float]]:
+    def aim_centrepoint(
+        self, fraction: float = 0.40,
+    ) -> Optional[Tuple[float, float]]:
+        """Mean aim position over the final ``fraction`` of on-target points.
+
+        Falls back to the full trace when no on-target points exist.
         """
-        Mean aim position over the last `fraction` of ON-TARGET points only.
-        This is the most meaningful measure of where you were holding.
-        """
-        pts = self.on_target_points
-        if not pts:
-            pts = self.points      # fallback if no on-target points
+        pts = self.on_target_points or self.points
         if not pts:
             return None
         n = max(1, int(len(pts) * fraction))
-        pts = pts[-n:]
-        return (float(np.mean([p.aim_mm[0] for p in pts])),
-                float(np.mean([p.aim_mm[1] for p in pts])))
+        tail = pts[-n:]
+        return (
+            float(np.mean([p.aim_mm[0] for p in tail])),
+            float(np.mean([p.aim_mm[1] for p in tail])),
+        )
 
     def recompute_colours(
         self,
@@ -115,20 +93,15 @@ class ShotTrace:
         preshot_s: float = 1.0,
         final_s: float = 0.2,
         tail_only: bool = False,
-    ):
-        """
-        (Re)compute cached_colours for all or just the tail of the trace.
-        Call with tail_only=True after fired_time is set — only the last
-        few seconds of points change colour on firing, the rest stay the same.
-        """
+    ) -> None:
+        """Refresh ``cached_colours`` for all or just the trailing points."""
         params = (col_approach, col_hold, col_preshot, col_final,
                   preshot_s, final_s)
         n = len(self.points)
         if not self.cached_colours or len(self.cached_colours) != n:
-            tail_only = False  # full recompute if lengths mismatch
+            tail_only = False
 
         if tail_only and self.fired_time is not None:
-            # Only recompute points within preshot_s + 0.5s of fired_time
             recompute_from = 0
             for i in range(n - 1, -1, -1):
                 if self.fired_time - self.points[i].timestamp > preshot_s + 0.5:
@@ -147,21 +120,20 @@ class ShotTrace:
 
     def colour_for_point(
         self, idx: int,
-        col_approach: Tuple[int,int,int] = (60, 60, 60),
-        col_hold:     Tuple[int,int,int] = (80, 190, 40),
-        col_preshot:  Tuple[int,int,int] = (0, 208, 240),
-        col_final:    Tuple[int,int,int] = (32, 48, 227),
+        col_approach: Tuple[int, int, int] = (60, 60, 60),
+        col_hold: Tuple[int, int, int] = (80, 190, 40),
+        col_preshot: Tuple[int, int, int] = (0, 208, 240),
+        col_final: Tuple[int, int, int] = (32, 48, 227),
         preshot_s: float = 1.0,
-        final_s:   float = 0.2,
+        final_s: float = 0.2,
     ) -> Tuple[int, int, int]:
-        """
-        BGR colour per trace point. Colour params come from the renderer
-        (which reads them from user config) so they're fully customisable.
+        """BGR colour for a trace point based on zone and time-to-fire.
 
-        Approach zone : col_approach (default dark grey)
-        Hold > 1.0s   : col_hold (default green), brightness ramps up
-        Hold 1.0–0.2s : lerp col_hold → col_preshot (default yellow)
-        Hold < 0.2s   : lerp col_preshot → col_final (default red)
+        Approach points are dimmed grey. Hold points fade from dim to
+        full ``col_hold``. Once the shot has fired, points within
+        ``preshot_s`` of fire are interpolated towards ``col_preshot``,
+        and points within ``final_s`` are interpolated towards
+        ``col_final``.
         """
         if idx >= len(self.points):
             return col_hold
@@ -170,39 +142,40 @@ class ShotTrace:
 
         if pt.zone == ZONE_APPROACH:
             n = len(self.points)
-            a = 0.3 + 0.5 * (idx / max(n - 1, 1))
-            return tuple(int(c * a) for c in col_approach)
+            alpha = 0.3 + 0.5 * (idx / max(n - 1, 1))
+            return tuple(int(c * alpha) for c in col_approach)
 
         if self.fired_time is None:
-            n = max(len(self.on_target_points), 1)
-            ot_idx = len([p for p in self.points[:idx+1]
-                          if p.zone == ZONE_ON_TARGET])
-            a = 0.25 + 0.75 * (ot_idx + 1) / n
-            return tuple(int(c * a) for c in col_hold)
+            on_target_total = max(len(self.on_target_points), 1)
+            ot_idx = sum(1 for p in self.points[:idx + 1]
+                         if p.zone == ZONE_ON_TARGET)
+            alpha = 0.25 + 0.75 * (ot_idx + 1) / on_target_total
+            return tuple(int(c * alpha) for c in col_hold)
 
         t_before = max(0.0, self.fired_time - pt.timestamp)
 
-        def _lerp(c1, c2, t):
+        def lerp(c1, c2, t):
             return tuple(int(a + t * (b - a)) for a, b in zip(c1, c2))
 
         if t_before > preshot_s:
-            total = self.fired_time - (self.on_target_points[0].timestamp
-                                       if self.on_target_points
-                                       else self.points[0].timestamp)
+            anchor = (self.on_target_points[0].timestamp
+                      if self.on_target_points else self.points[0].timestamp)
+            total = self.fired_time - anchor
             age = (pt.timestamp - self.points[0].timestamp) / max(total, 0.001)
-            a = 0.25 + 0.75 * age
-            return tuple(int(c * a) for c in col_hold)
-        elif t_before > final_s:
+            alpha = 0.25 + 0.75 * age
+            return tuple(int(c * alpha) for c in col_hold)
+        if t_before > final_s:
             band = preshot_s - final_s
             t = (preshot_s - t_before) / band if band > 0 else 1.0
-            return _lerp(col_hold, col_preshot, t)
-        else:
-            t = (final_s - t_before) / final_s if final_s > 0 else 1.0
-            return _lerp(col_preshot, col_final, t)
+            return lerp(col_hold, col_preshot, t)
+        t = (final_s - t_before) / final_s if final_s > 0 else 1.0
+        return lerp(col_preshot, col_final, t)
 
 
 @dataclass
 class Shot:
+    """One recorded shot with optional trace and review flags."""
+
     index: int
     timestamp: float
     aim_mm: Tuple[float, float]
@@ -211,51 +184,54 @@ class Shot:
     series: int = 1
     trace: Optional[ShotTrace] = None
     aim_centrepoint: Optional[Tuple[float, float]] = None
-    # Shot flags (matching Scatt data model)
-    match_shot: bool = True    # counts toward result (vs sighter)
-    deleted: bool = False      # soft-deleted / false positive
-    favourite: bool = False    # marked for review
-    missed: bool = False       # missed the target entirely
+    match_shot: bool = True
+    deleted: bool = False
+    favourite: bool = False
+    missed: bool = False
     comments: str = ""
-    mark_index: int = 0    # which aiming mark (0 for single-mark targets)
+    mark_index: int = 0
 
     @property
     def radius_mm(self) -> float:
-        return math.sqrt(self.aim_mm[0] ** 2 + self.aim_mm[1] ** 2)
+        return math.hypot(self.aim_mm[0], self.aim_mm[1])
 
     @property
     def on_target_duration_s(self) -> float:
         return self.trace.on_target_duration_s() if self.trace else 0.0
 
 
-# ── Live CSV writer ───────────────────────────────────────────────────────────
-
 class LiveSessionWriter:
+    """CSV writer that flushes every shot immediately.
+
+    Opening one of these at series start guarantees that all completed
+    shots survive even if the app crashes mid-series.
     """
-    Opens a CSV file at series-start and appends each shot immediately.
-    Safe against crashes — every shot is flushed to disk as it's recorded.
-    """
-    HEADER = ["Shot", "Series", "Timestamp", "X_mm", "Y_mm", "Radius_mm",
-              "Score", "OnTarget_s", "ApproachTotal_s",
-              "ACP_X", "ACP_Y", "TracePoints"]
+
+    HEADER = [
+        "Shot", "Series", "Timestamp", "X_mm", "Y_mm", "Radius_mm",
+        "Score", "OnTarget_s", "ApproachTotal_s",
+        "ACP_X", "ACP_Y", "TracePoints",
+    ]
 
     def __init__(self, path: str):
         self.path = path
         os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
-        self._f = open(path, "w", newline="", buffering=1)  # line-buffered
+        self._f = open(path, "w", newline="", buffering=1)
         self._w = csv.writer(self._f)
         self._w.writerow(self.HEADER)
         self._f.flush()
 
-    def write_shot(self, shot: Shot):
+    def write_shot(self, shot: Shot) -> None:
         acp = shot.aim_centrepoint
         trace_pts = ""
         if shot.trace:
-            # Compact encoding: "t:x:y:zone|t:x:y:zone|..."
             trace_pts = "|".join(
-                f"{p.timestamp:.3f}:{p.aim_mm[0]:.2f}:{p.aim_mm[1]:.2f}:{p.zone[0]}"
+                f"{p.timestamp:.3f}:{p.aim_mm[0]:.2f}:"
+                f"{p.aim_mm[1]:.2f}:{p.zone[0]}"
                 for p in shot.trace.points
             )
+        approach_total = (
+            f"{shot.trace.total_duration_s():.3f}" if shot.trace else "0")
         self._w.writerow([
             shot.index, shot.series,
             f"{shot.timestamp:.3f}",
@@ -263,14 +239,14 @@ class LiveSessionWriter:
             f"{shot.radius_mm:.3f}",
             shot.score,
             f"{shot.on_target_duration_s:.3f}",
-            f"{shot.trace.total_duration_s():.3f}" if shot.trace else "0",
+            approach_total,
             f"{acp[0]:.3f}" if acp else "",
             f"{acp[1]:.3f}" if acp else "",
             trace_pts,
         ])
         self._f.flush()
 
-    def close(self):
+    def close(self) -> None:
         try:
             self._f.close()
         except Exception:
@@ -281,17 +257,42 @@ class LiveSessionWriter:
         return not self._f.closed
 
 
-# ── Session ───────────────────────────────────────────────────────────────────
+def _interpolate_aim(
+    points: List[TracePoint], target_time: float,
+) -> Tuple[float, float]:
+    """Aim position at ``target_time`` interpolated between trace points."""
+    if len(points) == 1:
+        return points[0].aim_mm
+
+    times = [p.timestamp for p in points]
+    t = max(times[0], min(times[-1], target_time))
+
+    lo, hi = 0, len(times) - 1
+    for i in range(len(times) - 1):
+        if times[i] <= t <= times[i + 1]:
+            lo, hi = i, i + 1
+            break
+
+    p0, p1 = points[lo], points[hi]
+    dt = times[hi] - times[lo]
+    if dt <= 0:
+        return p0.aim_mm
+    frac = (t - times[lo]) / dt
+    return (
+        p0.aim_mm[0] + frac * (p1.aim_mm[0] - p0.aim_mm[0]),
+        p0.aim_mm[1] + frac * (p1.aim_mm[1] - p0.aim_mm[1]),
+    )
+
 
 class Session:
-    """
-    Manages trace recording, shot registration, and live file I/O.
+    """Aim trace recording, shot registration, statistics and live I/O.
 
-    Zones:
-        approach_radius_mm  = scoring_radius_mm * APPROACH_ZONE_FACTOR
-        on_target_radius_mm = scoring_radius_mm
-
-    A shot is rejected (returns None) if aim_mm is outside approach_radius_mm.
+    Args:
+        name: Session name used in saved file names.
+        shots_per_series: Default series length.
+        scoring_radius_mm: ``card_radius + calibre_radius`` in mm. Drives
+            the on-target and approach zones used to classify trace
+            points and reject false positives.
     """
 
     def __init__(
@@ -303,8 +304,8 @@ class Session:
         self.name = name
         self.shots_per_series = shots_per_series
         self.scoring_radius_mm = scoring_radius_mm
-        self.fading_trace_duration_s = 2.0   # overridden by app from cfg
-        self.acp_fraction = 0.40              # overridden by app from cfg
+        self.fading_trace_duration_s = 2.0
+        self.acp_fraction = 0.40
         self.approach_radius_mm = scoring_radius_mm * APPROACH_ZONE_FACTOR
         self.on_target_radius_mm = scoring_radius_mm
 
@@ -313,49 +314,40 @@ class Session:
         self.start_time = time.time()
         self._shot_counter = 0
 
-        # Live trace state
         self.active_trace: ShotTrace = ShotTrace()
         self._in_approach_zone: bool = False
 
-        # Post-shot fading trace
         self.fading_trace: Optional[ShotTrace] = None
-        self._fading_first_seen: float = 0.0   # when UI first saw it
-        self._fading_pending: bool = False       # True = new fading, not yet displayed
+        self._fading_first_seen: float = 0.0
+        self._fading_pending: bool = False
 
-        # Live file writer (None until start_series() called)
         self._writer: Optional[LiveSessionWriter] = None
         self.series_file_path: Optional[str] = None
 
-    # ── Series file management ────────────────────────────────────────────────
-
     def start_series(self, save_dir: str) -> str:
-        """
-        Open a new live CSV file for this series.
-        Files are organised into daily subfolders: save_dir/YYYY-MM-DD/
-        Returns the file path.
+        """Open a new live CSV file for the current series.
+
+        Files are organised into per-day subfolders
+        (``YYYY-MM-DD/HH-MM-SS_<name>_seriesN.csv``).
         """
         if self._writer and self._writer.is_open:
             self._writer.close()
-        # Daily subfolder
-        day_folder = time.strftime("%Y-%m-%d")
-        day_dir = os.path.join(save_dir, day_folder)
+        day_dir = os.path.join(save_dir, time.strftime("%Y-%m-%d"))
         os.makedirs(day_dir, exist_ok=True)
-        # File name: HH-MM-SS_name_seriesN  (date already in folder)
         ts = time.strftime("%H-%M-%S")
         safe_name = self.name.replace(" ", "_")
-        fname = f"{ts}_{safe_name}_series{self.current_series}.csv"
-        path = os.path.join(day_dir, fname)
+        path = os.path.join(
+            day_dir, f"{ts}_{safe_name}_series{self.current_series}.csv")
         self._writer = LiveSessionWriter(path)
         self.series_file_path = path
         self.start_time = time.time()
         return path
 
-    def end_series(self):
-        """Close the live writer and write a JSON archive alongside."""
+    def end_series(self) -> None:
+        """Close the live writer and persist a JSON archive alongside."""
         if self._writer:
             self._writer.close()
             self._writer = None
-        # Write companion JSON so the history viewer can load rich data
         if self.series_file_path and self.shots:
             try:
                 json_path = self.series_file_path.replace(".csv", ".json")
@@ -368,42 +360,37 @@ class Session:
     def series_active(self) -> bool:
         return self._writer is not None and self._writer.is_open
 
-    # ── Trace / aim management ────────────────────────────────────────────────
+    def update_aim(
+        self, aim_mm: Tuple[float, float],
+    ) -> Tuple[bool, bool]:
+        """Feed the latest zeroed aim position to the active trace.
 
-    def update_aim(self, aim_mm: Tuple[float, float]) -> Tuple[bool, bool]:
+        Returns ``(in_approach_zone, on_target)``.
         """
-        Feed the current zeroed aim position.
-        Records to the active trace (approach + on-target).
-        Returns (in_approach_zone, on_target).
-        """
-        radius = math.sqrt(aim_mm[0] ** 2 + aim_mm[1] ** 2)
+        radius = math.hypot(aim_mm[0], aim_mm[1])
         in_approach = radius <= self.approach_radius_mm
-        on_target   = radius <= self.on_target_radius_mm
+        on_target = radius <= self.on_target_radius_mm
 
-        if in_approach:
-            if not self._in_approach_zone:
-                # Entered approach zone — start fresh trace for this shot
-                self.active_trace = ShotTrace()
-                self._in_approach_zone = True
+        if not in_approach:
+            self._in_approach_zone = False
+            return in_approach, on_target
 
-            zone = ZONE_ON_TARGET if on_target else ZONE_APPROACH
-            self.active_trace.points.append(
-                TracePoint(timestamp=time.time(), aim_mm=aim_mm, zone=zone))
-            # Pre-compute colour for new point using cached renderer params.
-            # Falls back to a default if params not yet set (first frame).
-            cp = self.active_trace._cache_params
-            if cp:
-                col = self.active_trace.colour_for_point(
-                    len(self.active_trace.points) - 1, *cp[:4],
-                    preshot_s=cp[4], final_s=cp[5])
-            else:
-                col = (80, 190, 40)   # default green until params arrive
-            self.active_trace.cached_colours.append(col)
+        if not self._in_approach_zone:
+            self.active_trace = ShotTrace()
+            self._in_approach_zone = True
+
+        zone = ZONE_ON_TARGET if on_target else ZONE_APPROACH
+        self.active_trace.points.append(
+            TracePoint(timestamp=time.time(), aim_mm=aim_mm, zone=zone))
+
+        cp = self.active_trace._cache_params
+        if cp:
+            colour = self.active_trace.colour_for_point(
+                len(self.active_trace.points) - 1, *cp[:4],
+                preshot_s=cp[4], final_s=cp[5])
         else:
-            if self._in_approach_zone:
-                self._in_approach_zone = False
-            # Outside approach zone — don't record, but don't reset trace either
-            # (preserves partial approach if tracking briefly loses the markers)
+            colour = (80, 190, 40)
+        self.active_trace.cached_colours.append(colour)
 
         return in_approach, on_target
 
@@ -416,59 +403,29 @@ class Session:
         mark_index: int = 0,
         defer_write: bool = False,
     ) -> Optional[Shot]:
+        """Register a shot, returning ``None`` if the aim was off-target.
+
+        When ``shot_timestamp`` is provided, the trace history is
+        interpolated to find the aim at the exact audio-trigger moment.
+        This eliminates the lag between audio detection and the next
+        camera frame.
         """
-        Register a shot.
+        if shot_timestamp is not None and self.active_trace.points:
+            aim_mm = _interpolate_aim(
+                self.active_trace.points, shot_timestamp)
 
-        If shot_timestamp is provided (the exact time.time() when the audio
-        callback fired), the aim position is looked up retroactively from the
-        trace — finding the trace point whose timestamp is closest to
-        shot_timestamp, then linearly interpolating between the two nearest
-        points for sub-frame accuracy.  This eliminates software lag between
-        audio detection and camera frame capture.
-
-        Falls back to the supplied aim_mm if the trace has no points yet.
-        Returns None (rejected) if aim is outside the approach zone.
-        """
-        # ── Retroactive position lookup ──────────────────────────────────────
-        if shot_timestamp is not None and len(self.active_trace.points) >= 2:
-            pts = self.active_trace.points
-            times = [p.timestamp for p in pts]
-            # Find the two bracketing points
-            # Clamp to trace range (shot may be right at the end)
-            t = max(times[0], min(times[-1], shot_timestamp))
-            # Find insertion index
-            lo, hi = 0, len(times) - 1
-            for i in range(len(times) - 1):
-                if times[i] <= t <= times[i + 1]:
-                    lo, hi = i, i + 1
-                    break
-            p0, p1 = pts[lo], pts[hi]
-            dt = times[hi] - times[lo]
-            if dt > 0:
-                frac = (t - times[lo]) / dt
-                x = p0.aim_mm[0] + frac * (p1.aim_mm[0] - p0.aim_mm[0])
-                y = p0.aim_mm[1] + frac * (p1.aim_mm[1] - p0.aim_mm[1])
-                aim_mm = (x, y)
-            else:
-                aim_mm = p0.aim_mm
-        elif shot_timestamp is not None and len(self.active_trace.points) == 1:
-            aim_mm = self.active_trace.points[0].aim_mm
-
-        radius = math.sqrt(aim_mm[0] ** 2 + aim_mm[1] ** 2)
+        radius = math.hypot(aim_mm[0], aim_mm[1])
         if radius > self.approach_radius_mm:
-            return None   # reject — camera not on or near target
+            return None
 
         self._shot_counter += 1
         trace = self.active_trace
         trace.fired_time = shot_timestamp or time.time()
         trace.state = "fired"
-        # Recompute only the tail of the cached colours — the preshot/final
-        # colour zones only affect the last ~1-2 seconds before the shot.
-        # The bulk of the trace (hold zone) is already correctly cached.
         if trace._cache_params:
             cp = trace._cache_params
-            trace.recompute_colours(*cp[:4], preshot_s=cp[4], final_s=cp[5],
-                                    tail_only=True)
+            trace.recompute_colours(
+                *cp[:4], preshot_s=cp[4], final_s=cp[5], tail_only=True)
 
         shot = Shot(
             index=self._shot_counter,
@@ -483,69 +440,66 @@ class Session:
         )
         self.shots.append(shot)
 
-        # Write to live file immediately (unless caller wants to rescore first)
         if not defer_write and self._writer and self._writer.is_open:
             try:
                 self._writer.write_shot(shot)
             except Exception as e:
                 print(f"[LiveWriter] {e}")
 
-        # Set up fading trace — mark as pending, timer starts on first display
         self.fading_trace = trace
         self._fading_pending = True
         self._fading_first_seen = 0.0
 
-        # Fresh trace for the next shot
         self.active_trace = ShotTrace()
         self._in_approach_zone = False
         return shot
 
     def get_fading_trace(self) -> Optional[ShotTrace]:
-        """
-        Return the post-shot fading trace, or None if expired.
-        The 2-second timer starts from the FIRST call after a shot —
-        i.e. from when the UI actually renders it, not when it was recorded.
+        """Post-shot fading trace, or ``None`` once the fade window ends.
+
+        The fade timer starts on the first call after a shot is recorded,
+        so the window measures wall-clock UI display time rather than
+        the shot timestamp.
         """
         if self.fading_trace is None:
             return None
 
         now = time.time()
         if self._fading_pending:
-            # First time the UI is asking — start the clock now
             self._fading_first_seen = now
             self._fading_pending = False
 
         age = now - self._fading_first_seen
-        fade_dur = getattr(self, "fading_trace_duration_s", 2.0)
-        if age > fade_dur:
+        fade_duration = getattr(self, "fading_trace_duration_s", 2.0)
+        if age > fade_duration:
             self.fading_trace = None
             return None
         return self.fading_trace
 
     @property
     def fading_age_s(self) -> float:
-        """Current age of the fading trace in seconds (0 if not active)."""
+        """Age of the fading trace in seconds, or ``0`` when inactive."""
         if self.fading_trace is None or self._fading_first_seen == 0.0:
             return 0.0
         return time.time() - self._fading_first_seen
 
     def undo_last_shot(self) -> Optional[Shot]:
-        if self.shots:
-            s = self.shots.pop()
-            self._shot_counter -= 1
-            self.fading_trace = None
-            self._fading_pending = False
-            return s
-        return None
+        if not self.shots:
+            return None
+        shot = self.shots.pop()
+        self._shot_counter -= 1
+        self.fading_trace = None
+        self._fading_pending = False
+        return shot
 
-    def clear_series(self):
+    def clear_series(self) -> None:
         self.end_series()
         self.current_series += 1
         self.active_trace = ShotTrace()
         self.fading_trace = None
         self._in_approach_zone = False
 
-    def reset(self):
+    def reset(self) -> None:
         self.end_series()
         self.shots = []
         self.current_series = 1
@@ -555,16 +509,13 @@ class Session:
         self.fading_trace = None
         self._in_approach_zone = False
 
-
-    # ── Statistics ────────────────────────────────────────────────────────────
-
     @property
     def total_score(self) -> float:
         return sum(s.score for s in self.shots if not s.deleted)
 
     @property
     def shot_count(self) -> int:
-        return len([s for s in self.shots if not s.deleted])
+        return sum(1 for s in self.shots if not s.deleted)
 
     @property
     def match_shots(self) -> List[Shot]:
@@ -596,56 +547,56 @@ class Session:
 
     @property
     def mean_radius_mm(self) -> Optional[float]:
-        """MR — Mean Radius."""
         c = self._scored_coords()
         if c is None:
             return None
-        return float(np.mean(np.sqrt(c[:,0]**2 + c[:,1]**2)))
+        return float(np.mean(np.sqrt(c[:, 0] ** 2 + c[:, 1] ** 2)))
 
     @property
     def extreme_spread_mm(self) -> Optional[float]:
-        """ES — Extreme Spread: largest distance between any two shots."""
         c = self._scored_coords()
         if c is None or len(c) < 2:
             return None
         return float(max(
             np.linalg.norm(c[i] - c[j])
-            for i in range(len(c)) for j in range(i+1, len(c))
+            for i in range(len(c)) for j in range(i + 1, len(c))
         ))
 
     @property
     def figure_of_merit_mm(self) -> Optional[float]:
-        """FOM — (ES_x + ES_y) / 2."""
         c = self._scored_coords()
         if c is None or len(c) < 2:
             return None
-        return (float(np.max(c[:,0]) - np.min(c[:,0])) +
-                float(np.max(c[:,1]) - np.min(c[:,1]))) / 2.0
+        return (
+            float(np.max(c[:, 0]) - np.min(c[:, 0]))
+            + float(np.max(c[:, 1]) - np.min(c[:, 1]))
+        ) / 2.0
 
     @property
     def std_x_mm(self) -> Optional[float]:
         c = self._scored_coords()
-        return float(np.std(c[:,0])) if c is not None and len(c) > 1 else None
+        return float(np.std(c[:, 0])) if c is not None and len(c) > 1 else None
 
     @property
     def std_y_mm(self) -> Optional[float]:
         c = self._scored_coords()
-        return float(np.std(c[:,1])) if c is not None and len(c) > 1 else None
+        return float(np.std(c[:, 1])) if c is not None and len(c) > 1 else None
 
     @property
     def cep_mm(self) -> Optional[float]:
-        """CEP — radius containing 50% of shots."""
+        """Circular error probable: radius enclosing 50% of shots."""
         c = self._scored_coords()
         if c is None or len(c) < 2:
             return None
-        return float(np.percentile(np.sqrt(c[:,0]**2 + c[:,1]**2), 50))
+        return float(
+            np.percentile(np.sqrt(c[:, 0] ** 2 + c[:, 1] ** 2), 50))
 
     @property
     def mean_point_of_impact(self) -> Optional[Tuple[float, float]]:
         c = self._scored_coords()
         if c is None:
             return None
-        return (float(np.mean(c[:,0])), float(np.mean(c[:,1])))
+        return float(np.mean(c[:, 0])), float(np.mean(c[:, 1]))
 
     @property
     def group_size_mm(self) -> Optional[float]:
@@ -663,26 +614,29 @@ class Session:
 
     @property
     def bbox_shots_mm(self) -> Optional[Tuple[float, float]]:
-        """W x H bounding box of match shots."""
+        """Width and height of the axis-aligned bounding box (mm)."""
         c = self._scored_coords()
         if c is None or len(c) < 2:
             return None
-        return (float(np.max(c[:,0]) - np.min(c[:,0])),
-                float(np.max(c[:,1]) - np.min(c[:,1])))
+        return (
+            float(np.max(c[:, 0]) - np.min(c[:, 0])),
+            float(np.max(c[:, 1]) - np.min(c[:, 1])),
+        )
 
     @property
     def avg_on_target_s(self) -> Optional[float]:
-        vals = [s.on_target_duration_s for s in self.shots
-                if s.on_target_duration_s > 0 and not s.deleted]
-        return float(np.mean(vals)) if vals else None
+        values = [
+            s.on_target_duration_s for s in self.shots
+            if s.on_target_duration_s > 0 and not s.deleted
+        ]
+        return float(np.mean(values)) if values else None
 
     @property
     def duration_s(self) -> float:
         return time.time() - self.start_time
 
-    # ── Full JSON save (end of session) ──────────────────────────────────────
-
-    def save_json(self, path: str):
+    def save_json(self, path: str) -> None:
+        """Write a full session archive (including trace points) as JSON."""
         os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
         data = {
             "name": self.name,
@@ -698,7 +652,8 @@ class Session:
                     "score": s.score,
                     "ring_index": s.ring_index,
                     "on_target_s": s.on_target_duration_s,
-                    "aim_centrepoint": list(s.aim_centrepoint) if s.aim_centrepoint else None,
+                    "aim_centrepoint": (
+                        list(s.aim_centrepoint) if s.aim_centrepoint else None),
                     "trace": [
                         {"t": p.timestamp, "x": p.aim_mm[0],
                          "y": p.aim_mm[1], "z": p.zone}
@@ -711,13 +666,16 @@ class Session:
         with open(path, "w") as f:
             json.dump(data, f, indent=2)
 
-    def save_csv(self, path: str):
-        """Summary CSV (one row per shot, no trace points)."""
-        os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
+    def save_csv(self, path: str) -> None:
+        """Summary CSV with one row per shot and no trace points."""
+        os.makedirs(os.path.dirname(os.path.abspath(path)) or ".",
+                    exist_ok=True)
         with open(path, "w", newline="") as f:
             w = csv.writer(f)
-            w.writerow(["Shot", "Series", "X_mm", "Y_mm", "Radius_mm",
-                        "Score", "OnTarget_s", "ACP_X", "ACP_Y", "Timestamp"])
+            w.writerow([
+                "Shot", "Series", "X_mm", "Y_mm", "Radius_mm",
+                "Score", "OnTarget_s", "ACP_X", "ACP_Y", "Timestamp",
+            ])
             for s in self.shots:
                 acp = s.aim_centrepoint
                 w.writerow([
@@ -735,7 +693,10 @@ class Session:
             "name": self.name,
             "shots": self.shot_count,
             "total_score": self.total_score,
-            "avg_score": round(self.total_score / self.shot_count, 2) if self.shot_count else 0,
+            "avg_score": (
+                round(self.total_score / self.shot_count, 2)
+                if self.shot_count else 0
+            ),
             "mean_radius_mm": self.mean_radius_mm,
             "group_size_mm": self.group_size_mm,
             "mean_poi": self.mean_point_of_impact,
@@ -744,182 +705,189 @@ class Session:
         }
 
 
-# ── History helpers ───────────────────────────────────────────────────────────
+def _time_str_from_filename(fname: str) -> str:
+    """Extract the time portion of either the new or legacy filename format.
 
-def _load_session_file(path: str, fname: str, day_label: str) -> Optional[dict]:
-    """Load a single .json or .csv session file. Returns a dict or None."""
+    New: ``HH-MM-SS_name_seriesN.csv``
+    Legacy: ``session_YYYYMMDD_HHMMSS_name_seriesN.csv``
+    """
+    try:
+        parts = fname.split("_")
+        if parts[0] == "session" and len(parts) >= 3:
+            stamp = parts[2]
+            return f"{stamp[:2]}:{stamp[2:4]}:{stamp[4:6]}"
+        return parts[0].replace("-", ":")
+    except Exception:
+        return "—"
+
+
+def _load_json_session(
+    path: str, fname: str, base: str, day_label: str,
+) -> Optional[dict]:
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except Exception:
+        return None
+
+    shots = data.get("shots", [])
+    scores = [s["score"] for s in shots]
+    ot = [s["on_target_s"] for s in shots if s.get("on_target_s", 0) > 0]
+    return {
+        "filename": fname, "path": path, "base": base, "day": day_label,
+        "name": data.get("name", fname),
+        "date": time.strftime("%H:%M",
+                              time.localtime(data.get("start_time", 0))),
+        "shot_count": len(shots),
+        "total_score": round(sum(scores), 1),
+        "avg_score": round(sum(scores) / len(scores), 2) if scores else 0,
+        "duration_s": round(data.get("duration_s", 0)),
+        "avg_on_target_s": round(sum(ot) / len(ot), 2) if ot else 0,
+        "raw": data, "source": "json",
+    }
+
+
+def _load_csv_session(
+    path: str, fname: str, base: str, day_label: str,
+) -> Optional[dict]:
+    try:
+        with open(path, newline="") as f:
+            rows = list(csv.DictReader(f))
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    scores: list = []
+    ot_vals: list = []
+    for row in rows:
+        try:
+            score = float(row.get("Score", 0))
+            if score > 0:
+                scores.append(score)
+            ot = float(row.get("OnTarget_s", 0))
+            if ot > 0:
+                ot_vals.append(ot)
+        except (ValueError, TypeError):
+            pass
+
+    return {
+        "filename": fname, "path": path, "base": base, "day": day_label,
+        "name": fname.replace(".csv", ""),
+        "date": _time_str_from_filename(fname),
+        "shot_count": len(rows),
+        "total_score": round(sum(scores), 1),
+        "avg_score": round(sum(scores) / len(scores), 2) if scores else 0,
+        "duration_s": 0,
+        "avg_on_target_s": (
+            round(sum(ot_vals) / len(ot_vals), 2) if ot_vals else 0),
+        "raw": {"shots": [
+            {
+                "index": row.get("Shot", ""),
+                "score": float(row.get("Score", 0)),
+                "aim_mm": [float(row.get("X_mm", 0)),
+                           float(row.get("Y_mm", 0))],
+                "on_target_s": float(row.get("OnTarget_s", 0)),
+                "aim_centrepoint": (
+                    [float(row.get("ACP_X", 0)), float(row.get("ACP_Y", 0))]
+                    if row.get("ACP_X") else None),
+                "series": int(row.get("Series", 1)),
+                "timestamp": float(row.get("Timestamp", 0)),
+                "trace": [],
+            }
+            for row in rows
+        ]},
+        "source": "csv",
+    }
+
+
+def _load_session_file(
+    path: str, fname: str, day_label: str,
+) -> Optional[dict]:
+    """Load a single session file (.json or .csv) into a dict."""
     base = fname.rsplit(".", 1)[0]
-
     if fname.endswith(".json"):
-        try:
-            with open(path) as f:
-                data = json.load(f)
-            shots  = data.get("shots", [])
-            scores = [s["score"] for s in shots]
-            ot     = [s["on_target_s"] for s in shots if s.get("on_target_s", 0) > 0]
-            return {
-                "filename": fname, "path": path, "base": base,
-                "day": day_label,
-                "name": data.get("name", fname),
-                "date": time.strftime("%H:%M",
-                          time.localtime(data.get("start_time", 0))),
-                "shot_count": len(shots),
-                "total_score": round(sum(scores), 1),
-                "avg_score": round(sum(scores)/len(scores), 2) if scores else 0,
-                "duration_s": round(data.get("duration_s", 0)),
-                "avg_on_target_s": round(sum(ot)/len(ot), 2) if ot else 0,
-                "raw": data, "source": "json",
-            }
-        except Exception:
-            return None
-
-    elif fname.endswith(".csv"):
-        try:
-            with open(path, newline="") as f:
-                rows = list(csv.DictReader(f))
-            if not rows:
-                return None
-            scores, ot_vals = [], []
-            for r in rows:
-                try:
-                    sc = float(r.get("Score", 0))
-                    if sc > 0: scores.append(sc)
-                    ot = float(r.get("OnTarget_s", 0))
-                    if ot > 0: ot_vals.append(ot)
-                except (ValueError, TypeError):
-                    pass
-            # Time from filename.
-            # New format:  HH-MM-SS_name_seriesN.csv  → parts[0] = HH-MM-SS
-            # Old format:  session_YYYYMMDD_HHMMSS_name_seriesN.csv
-            time_str = "—"
-            try:
-                parts = fname.split("_")
-                if parts[0] == "session" and len(parts) >= 3:
-                    # Old format — extract HHMMSS from parts[2]
-                    h = parts[2][:2]; m = parts[2][2:4]; s = parts[2][4:6]
-                    time_str = f"{h}:{m}:{s}"
-                else:
-                    time_str = parts[0].replace("-", ":")   # HH:MM:SS
-            except Exception:
-                pass
-            name = fname.replace(".csv", "")
-            return {
-                "filename": fname, "path": path, "base": base,
-                "day": day_label,
-                "name": name, "date": time_str,
-                "shot_count": len(rows),
-                "total_score": round(sum(scores), 1),
-                "avg_score": round(sum(scores)/len(scores), 2) if scores else 0,
-                "duration_s": 0,
-                "avg_on_target_s": round(sum(ot_vals)/len(ot_vals), 2) if ot_vals else 0,
-                "raw": {"shots": [
-                    {"index": r.get("Shot",""), "score": float(r.get("Score",0)),
-                     "aim_mm": [float(r.get("X_mm",0)), float(r.get("Y_mm",0))],
-                     "on_target_s": float(r.get("OnTarget_s",0)),
-                     "aim_centrepoint": (
-                         [float(r.get("ACP_X",0)), float(r.get("ACP_Y",0))]
-                         if r.get("ACP_X") else None),
-                     "series": int(r.get("Series",1)),
-                     "timestamp": float(r.get("Timestamp", 0)),
-                     "trace": [],
-                    } for r in rows
-                ]},
-                "source": "csv",
-            }
-        except Exception:
-            return None
+        return _load_json_session(path, fname, base, day_label)
+    if fname.endswith(".csv"):
+        return _load_csv_session(path, fname, base, day_label)
     return None
 
 
-def load_session_history(save_dir: str) -> dict:
+def _scan_session_dir(dirpath: str, day_label: str) -> dict:
+    """Load all JSON sessions in ``dirpath`` and any CSV sessions whose
+    base name has no JSON counterpart.
     """
-    Load all saved sessions from save_dir, organised by day.
+    entries: dict = {}
+    seen_bases: set = set()
+    for fname in sorted(os.listdir(dirpath)):
+        if not fname.endswith(".json"):
+            continue
+        path = os.path.join(dirpath, fname)
+        if not os.path.isfile(path):
+            continue
+        entry = _load_session_file(path, fname, day_label)
+        if entry:
+            entries[entry["base"]] = entry
+            seen_bases.add(entry["base"])
+    for fname in sorted(os.listdir(dirpath)):
+        if not fname.endswith(".csv"):
+            continue
+        path = os.path.join(dirpath, fname)
+        if not os.path.isfile(path):
+            continue
+        base = fname.rsplit(".", 1)[0]
+        if base in seen_bases:
+            continue
+        entry = _load_session_file(path, fname, day_label)
+        if entry:
+            entries[base] = entry
+    return entries
 
-    Walks save_dir recursively:
-      - YYYY-MM-DD/ subfolders → day-organised sessions (new format)
-      - files directly in save_dir → legacy flat sessions
 
-    Returns a dict:
-        {
-            "YYYY-MM-DD": [session_dict, ...],   # newest day first
-            ...
-        }
-    Each session_dict has: filename, path, base, day, name, date,
-    shot_count, total_score, avg_score, duration_s, raw, source.
+def load_session_history(save_dir: str) -> dict:
+    """Load saved sessions grouped by day.
 
-    Deduplicates: .json takes priority over .csv with the same base name.
+    Walks ``save_dir`` recursively. Subdirectories are treated as days
+    (``YYYY-MM-DD``); files directly in ``save_dir`` are grouped under
+    ``"Legacy"``. Returns a mapping of day label to the list of session
+    entries for that day, newest day first.
     """
     if not os.path.isdir(save_dir):
         return {}
 
-    # Collect all files grouped by day label
-    day_files: dict = {}   # day_label → {base: entry}
-
-    def _scan_dir(dirpath: str, day_label: str):
-        seen_bases = set()
-        entries = {}
-        # Pass 1: JSON files (preferred)
-        for fname in sorted(os.listdir(dirpath)):
-            if not fname.endswith(".json"):
-                continue
-            path = os.path.join(dirpath, fname)
-            if not os.path.isfile(path):
-                continue
-            e = _load_session_file(path, fname, day_label)
-            if e:
-                entries[e["base"]] = e
-                seen_bases.add(e["base"])
-        # Pass 2: CSV files (only if no matching JSON)
-        for fname in sorted(os.listdir(dirpath)):
-            if not fname.endswith(".csv"):
-                continue
-            path = os.path.join(dirpath, fname)
-            if not os.path.isfile(path):
-                continue
-            base = fname.rsplit(".", 1)[0]
-            if base in seen_bases:
-                continue
-            e = _load_session_file(path, fname, day_label)
-            if e:
-                entries[base] = e
-        return entries
-
-    # Scan day subfolders (YYYY-MM-DD pattern)
+    day_files: dict = {}
     for entry in os.listdir(save_dir):
         full = os.path.join(save_dir, entry)
         if os.path.isdir(full):
-            # Accept any folder as a day label
-            day_files[entry] = _scan_dir(full, entry)
+            day_files[entry] = _scan_session_dir(full, entry)
 
-    # Scan legacy flat files directly in save_dir
-    flat = _scan_dir(save_dir, "Legacy")
+    flat = _scan_session_dir(save_dir, "Legacy")
     if flat:
         day_files.setdefault("Legacy", {}).update(flat)
 
-    # Build ordered result: newest day first, entries newest first within day
-    result = {}
+    result: dict = {}
     for day in sorted(day_files.keys(), reverse=True):
-        entries = sorted(day_files[day].values(),
-                         key=lambda e: e["filename"], reverse=True)
+        entries = sorted(
+            day_files[day].values(),
+            key=lambda e: e["filename"], reverse=True,
+        )
         if entries:
             result[day] = entries
-
     return result
 
 
 def reconstruct_shot_traces(session_data: dict) -> List[ShotTrace]:
-    """Rebuild ShotTrace objects from saved JSON for the history viewer."""
-    traces = []
+    """Rebuild :class:`ShotTrace` objects from a saved JSON session."""
+    traces: List[ShotTrace] = []
     for s in session_data.get("shots", []):
-        tr = ShotTrace()
+        trace = ShotTrace()
         for pt in s.get("trace", []):
-            zone = pt.get("z", ZONE_ON_TARGET)
-            tr.points.append(TracePoint(
+            trace.points.append(TracePoint(
                 timestamp=pt["t"],
                 aim_mm=(pt["x"], pt["y"]),
-                zone=zone,
+                zone=pt.get("z", ZONE_ON_TARGET),
             ))
-        tr.fired_time = s.get("timestamp")
-        tr.state = "fired"
-        traces.append(tr)
+        trace.fired_time = s.get("timestamp")
+        trace.state = "fired"
+        traces.append(trace)
     return traces

--- a/core/smoother.py
+++ b/core/smoother.py
@@ -1,40 +1,41 @@
+"""Real-time smoothing for the live aim point.
+
+Two strategies are available:
+
+- ``EMASmoother`` applies a single-pole IIR low-pass filter to each axis.
+  No external dependencies; very low latency.
+- ``SavGolSmoother`` fits a low-degree polynomial across a rolling window,
+  preserving the shape of genuine movement while suppressing tremor.
+  Falls back to EMA when SciPy is unavailable.
+
+Both expose the same ``update(aim) -> aim`` interface and are designed to
+be called once per camera frame.
 """
-core/smoother.py
-Real-time trace smoothing for aim-point data.
 
-Two modes:
-  EMA  — Exponential Moving Average. Zero dependencies. Very low lag.
-          Good for general use. alpha controls responsiveness:
-          low alpha (0.2) = very smooth but laggy
-          high alpha (0.6) = less smooth but more responsive
-          Recommended: 0.35
-
-  SAVGOL — Savitzky-Golay filter over a rolling window. Requires scipy.
-            Preserves the shape of genuine movement (hold, trigger pull)
-            while removing high-frequency tremor and camera noise.
-            window=11, poly=2 is a good starting point for 30fps.
-            Falls back to EMA if scipy is not available.
-
-Both operate on (x, y) float tuples and are designed to be called
-once per camera frame with the latest zeroed aim position.
-"""
+from __future__ import annotations
 
 from collections import deque
-from typing import Optional, Tuple
+from typing import Optional, Protocol, Tuple
 
 import numpy as np
 
 
-# ── EMA smoother ─────────────────────────────────────────────────────────────
+Aim = Tuple[float, float]
+
+
+class Smoother(Protocol):
+    """Minimal interface every smoother implements."""
+
+    def update(self, aim: Aim) -> Aim: ...
+
+    def reset(self) -> None: ...
+
 
 class EMASmoother:
-    """
-    Single-pole IIR low-pass filter applied independently to x and y.
+    """Independent exponential moving average on each axis.
 
-    s_t = alpha * x_t + (1 - alpha) * s_{t-1}
-
-    alpha=1.0 means no smoothing (pass-through).
-    alpha=0.2 means heavy smoothing.
+    ``alpha`` controls responsiveness: 1.0 disables smoothing, lower
+    values smooth more heavily at the cost of latency.
     """
 
     def __init__(self, alpha: float = 0.35):
@@ -42,41 +43,34 @@ class EMASmoother:
         self._sx: Optional[float] = None
         self._sy: Optional[float] = None
 
-    def reset(self):
+    def reset(self) -> None:
         self._sx = None
         self._sy = None
 
-    def update(self, aim: Tuple[float, float]) -> Tuple[float, float]:
+    def update(self, aim: Aim) -> Aim:
         x, y = aim
         if self._sx is None:
             self._sx, self._sy = x, y
         else:
-            self._sx = self.alpha * x + (1.0 - self.alpha) * self._sx
-            self._sy = self.alpha * y + (1.0 - self.alpha) * self._sy
-        return (self._sx, self._sy)
+            a = self.alpha
+            self._sx = a * x + (1.0 - a) * self._sx
+            self._sy = a * y + (1.0 - a) * self._sy
+        return self._sx, self._sy
 
-
-# ── Savitzky-Golay smoother ───────────────────────────────────────────────────
 
 class SavGolSmoother:
-    """
-    Rolling Savitzky-Golay filter.
+    """Rolling Savitzky-Golay filter with EMA fallback.
 
-    Keeps a deque of the last `window` points and fits a polynomial of
-    degree `poly` to them. Returns the smoothed value at the centre of
-    the window — this introduces a lag of window//2 frames (~5–8 frames
-    at 30fps with window=11, i.e. ~170ms).
-
-    Falls back to EMA if scipy is unavailable.
-
-    window must be odd and > poly.
-    Recommended: window=11, poly=2 for 30fps; window=7, poly=2 for 60fps.
+    Buffers the last ``window`` aim points and fits a polynomial of degree
+    ``poly`` across them. The window must be odd and larger than ``poly``.
+    Recommended starting points: ``window=11, poly=2`` at 30 fps,
+    ``window=7, poly=2`` at 60 fps.
     """
 
     def __init__(self, window: int = 11, poly: int = 2,
                  fallback_alpha: float = 0.35):
         if window % 2 == 0:
-            window += 1   # must be odd
+            window += 1
         self.window = max(poly + 2, window)
         self.poly = poly
         self._buf_x: deque = deque(maxlen=self.window)
@@ -87,17 +81,17 @@ class SavGolSmoother:
     @staticmethod
     def _check_savgol() -> bool:
         try:
-            from scipy.signal import savgol_filter  # noqa
+            from scipy.signal import savgol_filter  # noqa: F401
             return True
         except ImportError:
             return False
 
-    def reset(self):
+    def reset(self) -> None:
         self._buf_x.clear()
         self._buf_y.clear()
         self._fallback.reset()
 
-    def update(self, aim: Tuple[float, float]) -> Tuple[float, float]:
+    def update(self, aim: Aim) -> Aim:
         x, y = aim
         self._buf_x.append(x)
         self._buf_y.append(y)
@@ -107,45 +101,49 @@ class SavGolSmoother:
 
         n = len(self._buf_x)
         if n < self.poly + 2:
-            # Not enough points yet — return EMA estimate
             return self._fallback.update(aim)
 
         from scipy.signal import savgol_filter
-        # Use however many points we have, ensure window is odd
+
+        # Use as much of the buffer as is available, but the window must
+        # be odd and at least ``poly + 2``.
         w = n if n % 2 == 1 else n - 1
-        w = max(self.poly + 2 if (self.poly + 2) % 2 == 1 else self.poly + 3, w)
+        min_w = self.poly + 2 if (self.poly + 2) % 2 == 1 else self.poly + 3
+        w = max(min_w, w)
         w = min(w, self.window if self.window % 2 == 1 else self.window - 1)
 
-        xs = np.array(self._buf_x)
-        ys = np.array(self._buf_y)
         try:
-            sx = savgol_filter(xs, w, self.poly)
-            sy = savgol_filter(ys, w, self.poly)
-            # Return the most recent smoothed value
-            return (float(sx[-1]), float(sy[-1]))
+            sx = savgol_filter(np.array(self._buf_x), w, self.poly)
+            sy = savgol_filter(np.array(self._buf_y), w, self.poly)
+            return float(sx[-1]), float(sy[-1])
         except Exception:
             return self._fallback.update(aim)
 
 
-# ── Factory ───────────────────────────────────────────────────────────────────
+class _PassThrough:
+    """No-op smoother used for ``mode='none'``."""
 
-def make_smoother(mode: str, **kwargs):
+    def update(self, aim: Aim) -> Aim:
+        return aim
+
+    def reset(self) -> None:
+        pass
+
+
+def make_smoother(mode: str, **kwargs) -> Smoother:
+    """Build a smoother by name.
+
+    Args:
+        mode: ``'none'``, ``'ema'`` or ``'savgol'``.
+        **kwargs: Forwarded to the selected smoother
+            (``alpha``, ``window``, ``poly``).
     """
-    mode: 'none'   — pass-through, no smoothing
-          'ema'    — Exponential Moving Average
-          'savgol' — Savitzky-Golay (falls back to EMA if scipy absent)
-    """
-    if mode == 'ema':
-        return EMASmoother(alpha=kwargs.get('alpha', 0.35))
-    elif mode == 'savgol':
+    if mode == "ema":
+        return EMASmoother(alpha=kwargs.get("alpha", 0.35))
+    if mode == "savgol":
         return SavGolSmoother(
-            window=kwargs.get('window', 11),
-            poly=kwargs.get('poly', 2),
-            fallback_alpha=kwargs.get('alpha', 0.35),
+            window=kwargs.get("window", 11),
+            poly=kwargs.get("poly", 2),
+            fallback_alpha=kwargs.get("alpha", 0.35),
         )
-    else:
-        # 'none' — identity smoother
-        class PassThrough:
-            def update(self, aim): return aim
-            def reset(self): pass
-        return PassThrough()
+    return _PassThrough()

--- a/core/target_renderer.py
+++ b/core/target_renderer.py
@@ -1,80 +1,95 @@
+"""Target canvas renderer.
+
+Composes the static target face once at construction time and overlays
+shot traces, holes, aim centrepoints, bounding boxes, the live aim
+crosshair and the optional zero-mode banner on each call to
+:meth:`TargetRenderer.render`.
 """
-core/target_renderer.py
-Renders the target face with per-shot colour traces, aim centrepoints,
-fading post-shot traces, and shot holes.
-"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Tuple
 
 import cv2
 import numpy as np
-from typing import List, Optional, Tuple
 
 from core.session import Shot, ShotTrace
 
 
-# ── Colour palette (BGR) ──────────────────────────────────────────────────────
-C_BG         = (22, 22, 28)
+# Static palette (BGR).
+C_BG = (22, 22, 28)
 C_RING_OUTER = (180, 180, 180)
-C_SHOT_RING  = (255, 255, 255)
-C_MPI        = (255, 180, 80)
-C_GROUP      = (255, 100, 100)
+C_SHOT_RING = (255, 255, 255)
+C_MPI = (255, 180, 80)
+C_GROUP = (255, 100, 100)
 
-def _hex_to_bgr(h: str) -> Tuple[int, int, int]:
-    """Convert #rrggbb hex string to OpenCV BGR tuple."""
-    h = h.lstrip("#")
-    r, g, b = int(h[0:2],16), int(h[2:4],16), int(h[4:6],16)
+
+def _hex_to_bgr(value: str) -> Tuple[int, int, int]:
+    """Convert ``#rrggbb`` to an OpenCV BGR tuple."""
+    h = value.lstrip("#")
+    r, g, b = int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
     return (b, g, r)
 
-# Defaults (overridden by display_cfg passed to TargetRenderer)
-C_SHOT_FILL  = (80,  80,  255)
-C_CROSSHAIR  = (0,   220, 100)
-C_MISS       = (60,  60,  200)
-C_ACP        = (255, 200,   0)
+
+def _effective_diameter_mm(target_cfg: dict) -> float:
+    """Visual diameter that must fit on the canvas.
+
+    For multi-mark targets this is the full span across all marks, not
+    the diameter of a single card.
+    """
+    diameter = target_cfg["diameter_mm"]
+    offsets = target_cfg.get("mark_offsets")
+    if not offsets:
+        return diameter
+    max_reach = max(math.hypot(mx, my) for mx, my in offsets)
+    return (max_reach + diameter / 2) * 2
 
 
 class TargetRenderer:
-    def __init__(self, canvas_size: Tuple[int, int], target_cfg: dict,
-                 display_calibre_mm: float = None,
-                 display_cfg: dict = None,
-                 zoom: float = 1.0):
+    """Render a digital target face with shot data overlaid."""
+
+    def __init__(
+        self,
+        canvas_size: Tuple[int, int],
+        target_cfg: dict,
+        display_calibre_mm: Optional[float] = None,
+        display_cfg: Optional[dict] = None,
+        zoom: float = 1.0,
+    ):
         self.cw, self.ch = canvas_size
         self.target_cfg = target_cfg
         self.calibre_mm = display_calibre_mm or target_cfg.get("calibre_mm", 4.5)
         self.zoom = max(0.1, float(zoom))
-        dc = display_cfg or {}
-        # Colours from display config (fall back to hardcoded defaults)
-        self.C_shot_fill = _hex_to_bgr(dc.get("colour_shot_fill",  "#5050ff"))
-        self.C_acp       = _hex_to_bgr(dc.get("colour_acp",        "#ffc800"))
-        self.C_crosshair = _hex_to_bgr(dc.get("colour_crosshair",  "#00dc64"))
-        self.C_miss      = _hex_to_bgr(dc.get("colour_miss",       "#3c3cd0"))
-        self.C_mpi       = _hex_to_bgr(dc.get("colour_mpi",        "#50b4ff"))
-        self.C_group     = _hex_to_bgr(dc.get("colour_group",      "#6464ff"))
-        self.trace_width = int(dc.get("trace_width", 1))
-        # Store colour config so ShotTrace.colour_for_point can use it
-        self.col_approach  = _hex_to_bgr(dc.get("colour_trace_approach", "#3c3c3c"))
-        self.col_hold      = _hex_to_bgr(dc.get("colour_trace_hold",     "#28be50"))
-        self.col_preshot   = _hex_to_bgr(dc.get("colour_trace_preshot",  "#f0d000"))
-        self.col_final     = _hex_to_bgr(dc.get("colour_trace_final",    "#e03020"))
-        self.trace_preshot_s = float(dc.get("trace_preshot_s", 1.0))
-        self.trace_final_s   = float(dc.get("trace_final_s",   0.2))
 
-        # For multi-mark targets, the effective visual diameter is larger than
-        # the single card diameter — use the full span of all marks.
-        target_dia = target_cfg["diameter_mm"]
-        mark_offsets = target_cfg.get("mark_offsets")
-        if mark_offsets:
-            import math as _m
-            max_reach = max(_m.sqrt(mx**2 + my**2) for mx, my in mark_offsets)
-            # Full span = furthest mark centre + one card radius on each side
-            target_dia = (max_reach + target_dia / 2) * 2
+        self._configure_colours(display_cfg or {})
+
         usable = min(self.cw, self.ch) * 0.88 * self.zoom
-        self.scale = usable / target_dia
+        self.scale = usable / _effective_diameter_mm(target_cfg)
 
         self.cx = self.cw // 2
         self.cy = self.ch // 2
 
         self._static = self._render_static()
 
-    # ── Public API ────────────────────────────────────────────────────────────
+    def _configure_colours(self, dc: dict) -> None:
+        self.C_shot_fill = _hex_to_bgr(dc.get("colour_shot_fill", "#5050ff"))
+        self.C_acp = _hex_to_bgr(dc.get("colour_acp", "#ffc800"))
+        self.C_crosshair = _hex_to_bgr(dc.get("colour_crosshair", "#00dc64"))
+        self.C_miss = _hex_to_bgr(dc.get("colour_miss", "#3c3cd0"))
+        self.C_mpi = _hex_to_bgr(dc.get("colour_mpi", "#50b4ff"))
+        self.C_group = _hex_to_bgr(dc.get("colour_group", "#6464ff"))
+        self.trace_width = int(dc.get("trace_width", 1))
+        self.col_approach = _hex_to_bgr(
+            dc.get("colour_trace_approach", "#3c3c3c"))
+        self.col_hold = _hex_to_bgr(
+            dc.get("colour_trace_hold", "#28be50"))
+        self.col_preshot = _hex_to_bgr(
+            dc.get("colour_trace_preshot", "#f0d000"))
+        self.col_final = _hex_to_bgr(
+            dc.get("colour_trace_final", "#e03020"))
+        self.trace_preshot_s = float(dc.get("trace_preshot_s", 1.0))
+        self.trace_final_s = float(dc.get("trace_final_s", 0.2))
 
     def render(
         self,
@@ -92,188 +107,208 @@ class TargetRenderer:
         highlighted_shot_trace: Optional[ShotTrace] = None,
         show_bbox_shots: bool = False,
         show_bbox_acp: bool = False,
-        show_dot_only: bool = False,   # True = tiny dot; False = full calibre circle
-        trace_alpha: float = 0.30,      # alpha for past traces (1.0 = full in review)
+        show_dot_only: bool = False,
+        trace_alpha: float = 0.30,
     ) -> np.ndarray:
+        """Compose and return the final BGR target frame."""
         canvas = self._static.copy()
 
-        # 1. Past shot traces (dim) — drawn BELOW holes
         if show_traces:
             for shot in shots:
                 if shot.series == current_series and shot.trace:
                     self._draw_shot_trace(canvas, shot.trace, alpha=trace_alpha)
 
-        # 2. Fading post-shot trace
         if fading_trace and fading_trace.points:
             fade_alpha = max(0.05, 1.0 - fading_age_s / 2.0)
-            self._draw_shot_trace(canvas, fading_trace, alpha=fade_alpha, width=2)
+            self._draw_shot_trace(canvas, fading_trace,
+                                  alpha=fade_alpha, width=2)
 
-        # 3. Active live trace
         if active_trace and active_trace.points:
             self._draw_shot_trace(canvas, active_trace, alpha=1.0, width=1)
 
-        # 4. Shot holes
         for shot in shots:
             self._draw_shot_hole(canvas, shot, current_series,
-                                  dot_only=show_dot_only)
+                                 dot_only=show_dot_only)
 
-        # 5. Highlighted trace — drawn ON TOP of shot holes
         if highlighted_shot_trace:
             self._draw_shot_trace(canvas, highlighted_shot_trace,
-                                   alpha=1.0, width=2)
+                                  alpha=1.0, width=2)
 
-        # 6. Aim centrepoints
         if show_acp:
             for shot in shots:
                 if shot.series == current_series and shot.aim_centrepoint:
                     self._draw_acp(canvas, shot.aim_centrepoint)
 
-        # 7. Bounding boxes
         series_shots = [s for s in shots if s.series == current_series]
         if show_bbox_shots and len(series_shots) >= 2:
             self._draw_bbox(canvas, [s.aim_mm for s in series_shots],
-                             color=(100, 200, 255))
+                            color=(100, 200, 255))
         if show_bbox_acp:
             acps = [s.aim_centrepoint for s in series_shots
                     if s.aim_centrepoint]
             if len(acps) >= 2:
                 self._draw_bbox(canvas, acps, color=self.C_acp)
 
-        # 8. MPI + group
         if show_mpi and len(series_shots) >= 2:
             self._draw_group(canvas, series_shots)
 
-        # 9. Live crosshair
         if live_aim_mm is not None:
             self._draw_live_aim(canvas, live_aim_mm)
 
-        # 10. Zero mode overlay
         if zero_mode:
             self._draw_zero_overlay(canvas)
 
         return canvas
 
-    def mm_to_px(self, mm: Tuple[float, float]) -> Tuple[int, int]:
-        return (int(self.cx + mm[0] * self.scale),
-                int(self.cy + mm[1] * self.scale))
+    def mm_to_px(self, point_mm: Tuple[float, float]) -> Tuple[int, int]:
+        """Convert mm offsets from target centre to canvas pixels."""
+        return (
+            int(self.cx + point_mm[0] * self.scale),
+            int(self.cy + point_mm[1] * self.scale),
+        )
 
     def radius_to_px(self, r_mm: float) -> int:
+        """Convert a millimetre radius to canvas pixels (minimum 1)."""
         return max(1, int(r_mm * self.scale))
 
-    # ── Static target face ────────────────────────────────────────────────────
-
     def _render_static(self) -> np.ndarray:
-        img    = np.full((self.ch, self.cw, 3), C_BG, dtype=np.uint8)
-        rings  = self.target_cfg["rings_mm"]
+        img = np.full((self.ch, self.cw, 3), C_BG, dtype=np.uint8)
+        rings = self.target_cfg["rings_mm"]
         scores = self.target_cfg["ring_scores"]
-        # Multi-mark: draw rings at each mark centre; single-mark: draw at canvas centre
         mark_offsets = self.target_cfg.get("mark_offsets")
-        centres = [self.mm_to_px((mx, my)) for mx, my in mark_offsets] \
-                  if mark_offsets else [(self.cx, self.cy)]
+
+        if mark_offsets:
+            centres = [self.mm_to_px((mx, my)) for mx, my in mark_offsets]
+        else:
+            centres = [(self.cx, self.cy)]
 
         for ci, (ocx, ocy) in enumerate(centres):
-            for i in reversed(range(len(rings))):
-                r = self.radius_to_px(rings[i])
-                fill = (15, 15, 15) if i >= len(rings) - 4 else (240, 240, 240)
-                cv2.circle(img, (ocx, ocy), r, fill, -1)
-                cv2.circle(img, (ocx, ocy), r, C_RING_OUTER, 1)
-                # Score labels only on first mark to avoid clutter
-                if ci == 0 and i < len(rings) - 1:
-                    sc  = scores[i]
-                    lbl = str(int(sc)) if sc == int(sc) else str(sc)
-                    tc  = (200, 200, 200) if i >= len(rings) - 4 else (80, 80, 80)
-                    mid_r = (rings[i] + (rings[i-1] if i > 0 else 0)) / 2
-                    lx = int(ocx + mid_r * self.scale * 0.6)
-                    cv2.putText(img, lbl, (lx, ocy + 4),
-                                cv2.FONT_HERSHEY_SIMPLEX, 0.35, tc, 1, cv2.LINE_AA)
-            cv2.circle(img, (ocx, ocy),
-                       max(2, self.radius_to_px(0.5)), (0, 0, 0), -1)
+            self._draw_rings(img, ocx, ocy, rings, scores, label=(ci == 0))
 
-        # Crosshair lines across full canvas (only for single-mark targets)
         if not mark_offsets:
-            hl = min(self.cw, self.ch) // 2
-            cv2.line(img, (self.cx - hl, self.cy), (self.cx + hl, self.cy), (40, 40, 45), 1)
-            cv2.line(img, (self.cx, self.cy - hl), (self.cx, self.cy + hl), (40, 40, 45), 1)
+            self._draw_canvas_crosshair(img)
 
-        # Approach zone boundary (2× scoring radius) — dashed grey circle
         approach_r = self.radius_to_px(self.target_cfg["rings_mm"][-1] * 2.0)
-        n_dash = 48
-        for i in range(n_dash):
-            if i % 2 == 0:
-                a1 = 2 * np.pi * i / n_dash
-                a2 = 2 * np.pi * (i + 1) / n_dash
-                for a in np.linspace(a1, a2, 4):
-                    px = int(self.cx + approach_r * np.cos(a))
-                    py = int(self.cy + approach_r * np.sin(a))
-                    cv2.circle(img, (px, py), 1, (50, 50, 60), -1)
-
+        self._draw_dotted_circle(img, self.cx, self.cy, approach_r,
+                                 colour=(50, 50, 60))
         return img
 
-    # ── Drawing helpers ───────────────────────────────────────────────────────
+    def _draw_rings(
+        self, img: np.ndarray, ocx: int, ocy: int,
+        rings: list, scores: list, label: bool,
+    ) -> None:
+        n_rings = len(rings)
+        for i in reversed(range(n_rings)):
+            r = self.radius_to_px(rings[i])
+            fill = (15, 15, 15) if i >= n_rings - 4 else (240, 240, 240)
+            cv2.circle(img, (ocx, ocy), r, fill, -1)
+            cv2.circle(img, (ocx, ocy), r, C_RING_OUTER, 1)
+            if not label or i >= n_rings - 1:
+                continue
+            score = scores[i]
+            text = str(int(score)) if score == int(score) else str(score)
+            colour = (200, 200, 200) if i >= n_rings - 4 else (80, 80, 80)
+            mid_r = (rings[i] + (rings[i - 1] if i > 0 else 0)) / 2
+            lx = int(ocx + mid_r * self.scale * 0.6)
+            cv2.putText(img, text, (lx, ocy + 4),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.35, colour, 1, cv2.LINE_AA)
+        cv2.circle(img, (ocx, ocy),
+                   max(2, self.radius_to_px(0.5)), (0, 0, 0), -1)
 
-    def _draw_shot_trace(self, img, trace: ShotTrace,
-                         alpha: float = 1.0, width: int = 1):
+    def _draw_canvas_crosshair(self, img: np.ndarray) -> None:
+        hl = min(self.cw, self.ch) // 2
+        cv2.line(img, (self.cx - hl, self.cy), (self.cx + hl, self.cy),
+                 (40, 40, 45), 1)
+        cv2.line(img, (self.cx, self.cy - hl), (self.cx, self.cy + hl),
+                 (40, 40, 45), 1)
+
+    @staticmethod
+    def _draw_dotted_circle(
+        img: np.ndarray, cx: int, cy: int, radius: int,
+        colour: Tuple[int, int, int] = (50, 50, 60), n_dashes: int = 48,
+    ) -> None:
+        for i in range(0, n_dashes, 2):
+            a1 = 2 * np.pi * i / n_dashes
+            a2 = 2 * np.pi * (i + 1) / n_dashes
+            for a in np.linspace(a1, a2, 4):
+                px = int(cx + radius * np.cos(a))
+                py = int(cy + radius * np.sin(a))
+                cv2.circle(img, (px, py), 1, colour, -1)
+
+    def _draw_shot_trace(
+        self, img: np.ndarray, trace: ShotTrace,
+        alpha: float = 1.0, width: int = 1,
+    ) -> None:
         pts = trace.points
-        if len(pts) < 2:
-            return
         n = len(pts)
+        if n < 2:
+            return
 
-        # Pass renderer params to trace so it can pre-compute colours.
-        # If params changed (user updated colours in settings), trigger
-        # a full recompute; otherwise colours are already cached.
         params = (self.col_approach, self.col_hold, self.col_preshot,
                   self.col_final, self.trace_preshot_s, self.trace_final_s)
         if trace._cache_params != params or len(trace.cached_colours) != n:
             trace.recompute_colours(*params[:4],
                                     preshot_s=params[4], final_s=params[5])
 
-        # Draw using cached colours — O(n) pixel ops, zero Python colour math
         colours = trace.cached_colours
         for i in range(1, n):
-            col = tuple(int(c * alpha) for c in colours[i])
+            colour = tuple(int(c * alpha) for c in colours[i])
             p1 = self.mm_to_px(pts[i - 1].aim_mm)
             p2 = self.mm_to_px(pts[i].aim_mm)
-            cv2.line(img, p1, p2, col, width, cv2.LINE_AA)
+            cv2.line(img, p1, p2, colour, width, cv2.LINE_AA)
 
-    def _draw_shot_hole(self, img, shot: Shot, current_series: int,
-                         dot_only: bool = False):
+    def _draw_shot_hole(
+        self, img: np.ndarray, shot: Shot, current_series: int,
+        dot_only: bool = False,
+    ) -> None:
         px = self.mm_to_px(shot.aim_mm)
 
         if shot.score == 0:
             hr = max(3, self.radius_to_px(self.calibre_mm / 2))
-            cv2.line(img, (px[0]-hr, px[1]-hr), (px[0]+hr, px[1]+hr), self.C_miss, 2, cv2.LINE_AA)
-            cv2.line(img, (px[0]+hr, px[1]-hr), (px[0]-hr, px[1]+hr), self.C_miss, 2, cv2.LINE_AA)
+            cv2.line(img, (px[0] - hr, px[1] - hr),
+                     (px[0] + hr, px[1] + hr), self.C_miss, 2, cv2.LINE_AA)
+            cv2.line(img, (px[0] + hr, px[1] - hr),
+                     (px[0] - hr, px[1] + hr), self.C_miss, 2, cv2.LINE_AA)
             return
 
-        a = 1.0 if shot.series == current_series else 0.45
-        fill = tuple(int(c * a) for c in self.C_shot_fill)
+        alpha = 1.0 if shot.series == current_series else 0.45
+        fill = tuple(int(c * alpha) for c in self.C_shot_fill)
 
         if dot_only:
-            # Just a small 3px red dot — clean minimal view
             cv2.circle(img, px, 3, fill, -1, cv2.LINE_AA)
-        else:
-            # Full calibre-sized circle
-            hr = max(2, self.radius_to_px(self.calibre_mm / 2))
-            cv2.circle(img, px, hr, fill, -1, cv2.LINE_AA)
-            cv2.circle(img, px, hr, C_SHOT_RING, 1, cv2.LINE_AA)
-            if shot.series == current_series:
-                lbl = (str(int(shot.score)) if shot.score == int(shot.score)
-                       else f"{shot.score:.1f}")
-                cv2.putText(img, lbl, (px[0] + hr + 2, px[1] + 4),
-                            cv2.FONT_HERSHEY_SIMPLEX, 0.38, (220, 220, 100),
-                            1, cv2.LINE_AA)
+            return
 
-    def _draw_acp(self, img, acp: Tuple[float, float]):
-        """Draw aim centrepoint — gold diamond marker."""
+        hr = max(2, self.radius_to_px(self.calibre_mm / 2))
+        cv2.circle(img, px, hr, fill, -1, cv2.LINE_AA)
+        cv2.circle(img, px, hr, C_SHOT_RING, 1, cv2.LINE_AA)
+        if shot.series != current_series:
+            return
+
+        score = shot.score
+        label = str(int(score)) if score == int(score) else f"{score:.1f}"
+        cv2.putText(img, label, (px[0] + hr + 2, px[1] + 4),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.38, (220, 220, 100),
+                    1, cv2.LINE_AA)
+
+    def _draw_acp(
+        self, img: np.ndarray, acp: Tuple[float, float],
+    ) -> None:
         px = self.mm_to_px(acp)
         s = 6
-        pts = np.array([[px[0], px[1]-s], [px[0]+s, px[1]],
-                         [px[0], px[1]+s], [px[0]-s, px[1]]], np.int32)
-        cv2.polylines(img, [pts], True, self.C_acp, 1, cv2.LINE_AA)
-        cv2.drawMarker(img, px, self.C_acp, cv2.MARKER_CROSS, 5, 1, cv2.LINE_AA)
+        diamond = np.array([
+            [px[0], px[1] - s],
+            [px[0] + s, px[1]],
+            [px[0], px[1] + s],
+            [px[0] - s, px[1]],
+        ], np.int32)
+        cv2.polylines(img, [diamond], True, self.C_acp, 1, cv2.LINE_AA)
+        cv2.drawMarker(img, px, self.C_acp,
+                       cv2.MARKER_CROSS, 5, 1, cv2.LINE_AA)
 
-    def _draw_bbox(self, img, points, color=(100, 200, 255)):
-        """Draw axis-aligned bounding box around a list of mm-coordinate points."""
+    def _draw_bbox(
+        self, img: np.ndarray, points: list,
+        color: Tuple[int, int, int] = (100, 200, 255),
+    ) -> None:
         if len(points) < 2:
             return
         xs = [p[0] for p in points]
@@ -281,7 +316,7 @@ class TargetRenderer:
         tl = self.mm_to_px((min(xs), min(ys)))
         br = self.mm_to_px((max(xs), max(ys)))
         cv2.rectangle(img, tl, br, color, 1, cv2.LINE_AA)
-        # Dimension labels
+
         w_mm = max(xs) - min(xs)
         h_mm = max(ys) - min(ys)
         mid_x = (tl[0] + br[0]) // 2
@@ -291,36 +326,44 @@ class TargetRenderer:
         cv2.putText(img, f"{h_mm:.1f}mm", (br[0] + 4, mid_y + 4),
                     cv2.FONT_HERSHEY_SIMPLEX, 0.35, color, 1, cv2.LINE_AA)
 
-    def _draw_group(self, img, shots: List[Shot]):
+    def _draw_group(self, img: np.ndarray, shots: List[Shot]) -> None:
         coords = np.array([s.aim_mm for s in shots])
         mpi = (float(np.mean(coords[:, 0])), float(np.mean(coords[:, 1])))
         mpx = self.mm_to_px(mpi)
-        cv2.drawMarker(img, mpx, self.C_mpi, cv2.MARKER_CROSS, 14, 2, cv2.LINE_AA)
+        cv2.drawMarker(img, mpx, self.C_mpi,
+                       cv2.MARKER_CROSS, 14, 2, cv2.LINE_AA)
         max_d = max(
             (float(np.linalg.norm(coords[i] - coords[j]))
-             for i in range(len(coords)) for j in range(i+1, len(coords))),
+             for i in range(len(coords)) for j in range(i + 1, len(coords))),
             default=0.0,
         )
         if max_d > 0:
-            cv2.circle(img, mpx, self.radius_to_px(max_d / 2), self.C_group, 1, cv2.LINE_AA)
+            cv2.circle(img, mpx, self.radius_to_px(max_d / 2),
+                       self.C_group, 1, cv2.LINE_AA)
 
-    def _draw_live_aim(self, img, aim_mm: Tuple[float, float]):
+    def _draw_live_aim(
+        self, img: np.ndarray, aim_mm: Tuple[float, float],
+    ) -> None:
         px = self.mm_to_px(aim_mm)
         s = 14
-        cv2.line(img, (px[0]-s, px[1]), (px[0]+s, px[1]), self.C_crosshair, 1, cv2.LINE_AA)
-        cv2.line(img, (px[0], px[1]-s), (px[0], px[1]+s), self.C_crosshair, 1, cv2.LINE_AA)
+        cv2.line(img, (px[0] - s, px[1]), (px[0] + s, px[1]),
+                 self.C_crosshair, 1, cv2.LINE_AA)
+        cv2.line(img, (px[0], px[1] - s), (px[0], px[1] + s),
+                 self.C_crosshair, 1, cv2.LINE_AA)
         cv2.circle(img, px, 5, self.C_crosshair, 1, cv2.LINE_AA)
 
-    def _draw_zero_overlay(self, img: np.ndarray):
+    def _draw_zero_overlay(self, img: np.ndarray) -> None:
         h, w = img.shape[:2]
         overlay = img.copy()
-        cv2.rectangle(overlay, (4, 4), (w-4, h-4), (0, 165, 255), 8)
+        cv2.rectangle(overlay, (4, 4), (w - 4, h - 4), (0, 165, 255), 8)
         img[:] = cv2.addWeighted(overlay, 0.85, img, 0.15, 0)
         label = "ZERO MODE"
-        sub   = "Fire one shot to set zero point"
+        sub = "Fire one shot to set zero point"
         lw = cv2.getTextSize(label, cv2.FONT_HERSHEY_SIMPLEX, 0.9, 2)[0][0]
-        sw = cv2.getTextSize(sub,   cv2.FONT_HERSHEY_SIMPLEX, 0.45, 1)[0][0]
-        cv2.putText(img, label, ((w-lw)//2, 34),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.9, (0, 165, 255), 2, cv2.LINE_AA)
-        cv2.putText(img, sub, ((w-sw)//2, 56),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.45, (0, 165, 255), 1, cv2.LINE_AA)
+        sw = cv2.getTextSize(sub, cv2.FONT_HERSHEY_SIMPLEX, 0.45, 1)[0][0]
+        cv2.putText(img, label, ((w - lw) // 2, 34),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.9, (0, 165, 255), 2,
+                    cv2.LINE_AA)
+        cv2.putText(img, sub, ((w - sw) // 2, 56),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.45, (0, 165, 255), 1,
+                    cv2.LINE_AA)

--- a/core/target_renderer.py
+++ b/core/target_renderer.py
@@ -24,6 +24,12 @@ C_SHOT_RING = (255, 255, 255)
 C_MPI = (255, 180, 80)
 C_GROUP = (255, 100, 100)
 
+# Supersampling factor for the static target face. Rings, ring labels
+# and the canvas crosshair are drawn this many times larger and then
+# downscaled with INTER_AREA, which avoids the blocky aliasing OpenCV
+# produces when filling small circles directly at canvas resolution.
+_STATIC_SUPERSAMPLE = 3
+
 
 def _hex_to_bgr(value: str) -> Tuple[int, int, int]:
     """Convert ``#rrggbb`` to an OpenCV BGR tuple."""
@@ -172,27 +178,45 @@ class TargetRenderer:
         return max(1, int(r_mm * self.scale))
 
     def _render_static(self) -> np.ndarray:
-        img = np.full((self.ch, self.cw, 3), C_BG, dtype=np.uint8)
+        """Render the static target face once at supersampled resolution.
+
+        Drawing at ``_STATIC_SUPERSAMPLE`` times the canvas resolution
+        and downsampling with ``INTER_AREA`` produces smooth ring edges
+        and legible small text without resorting to a true vector
+        backend. The downscaled image is cached for reuse on every
+        :meth:`render` call.
+        """
+        ss = _STATIC_SUPERSAMPLE
+        big_w, big_h = self.cw * ss, self.ch * ss
+        big = np.full((big_h, big_w, 3), C_BG, dtype=np.uint8)
+
         rings = self.target_cfg["rings_mm"]
         scores = self.target_cfg["ring_scores"]
         mark_offsets = self.target_cfg.get("mark_offsets")
 
+        big_cx, big_cy = self.cx * ss, self.cy * ss
         if mark_offsets:
-            centres = [self.mm_to_px((mx, my)) for mx, my in mark_offsets]
+            centres = [
+                (int(big_cx + mx * self.scale * ss),
+                 int(big_cy + my * self.scale * ss))
+                for mx, my in mark_offsets
+            ]
         else:
-            centres = [(self.cx, self.cy)]
+            centres = [(big_cx, big_cy)]
 
         for ci, (ocx, ocy) in enumerate(centres):
-            self._draw_rings(img, ocx, ocy, rings, scores, label=(ci == 0))
+            self._draw_rings(big, ocx, ocy, rings, scores,
+                             label=(ci == 0), ss=ss)
 
         if not mark_offsets:
-            self._draw_canvas_crosshair(img)
+            self._draw_canvas_crosshair(big, ss=ss)
 
-        return img
+        return cv2.resize(big, (self.cw, self.ch),
+                          interpolation=cv2.INTER_AREA)
 
     def _draw_rings(
         self, img: np.ndarray, ocx: int, ocy: int,
-        rings: list, scores: list, label: bool,
+        rings: list, scores: list, label: bool, ss: int = 1,
     ) -> None:
         n_rings = len(rings)
         # The "bull" is the lighter-coloured central disc. Targets that
@@ -208,30 +232,40 @@ class TargetRenderer:
             limit = float(bull_dia) + 1e-6
             in_bull = lambda i: rings[i] * 2 <= limit  # noqa: E731
 
+        scale_px = self.scale * ss
+        ring_thickness = max(1, ss // 2)
+
         for i in reversed(range(n_rings)):
-            r = self.radius_to_px(rings[i])
+            r = max(1, int(rings[i] * scale_px))
             light = in_bull(i)
             fill = (240, 240, 240) if light else (15, 15, 15)
-            cv2.circle(img, (ocx, ocy), r, fill, -1)
-            cv2.circle(img, (ocx, ocy), r, C_RING_OUTER, 1)
+            cv2.circle(img, (ocx, ocy), r, fill, -1, cv2.LINE_AA)
+            cv2.circle(img, (ocx, ocy), r, C_RING_OUTER,
+                       ring_thickness, cv2.LINE_AA)
             if not label or i >= n_rings - 1:
                 continue
             score = scores[i]
             text = str(int(score)) if score == int(score) else str(score)
             colour = (80, 80, 80) if light else (200, 200, 200)
             mid_r = (rings[i] + (rings[i - 1] if i > 0 else 0)) / 2
-            lx = int(ocx + mid_r * self.scale * 0.6)
-            cv2.putText(img, text, (lx, ocy + 4),
-                        cv2.FONT_HERSHEY_SIMPLEX, 0.35, colour, 1, cv2.LINE_AA)
+            lx = int(ocx + mid_r * scale_px * 0.6)
+            ly = int(ocy + 4 * ss)
+            cv2.putText(img, text, (lx, ly),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.35 * ss, colour,
+                        max(1, ss // 2), cv2.LINE_AA)
         cv2.circle(img, (ocx, ocy),
-                   max(2, self.radius_to_px(0.5)), (0, 0, 0), -1)
+                   max(2 * ss, int(0.5 * scale_px)),
+                   (0, 0, 0), -1, cv2.LINE_AA)
 
-    def _draw_canvas_crosshair(self, img: np.ndarray) -> None:
-        hl = min(self.cw, self.ch) // 2
-        cv2.line(img, (self.cx - hl, self.cy), (self.cx + hl, self.cy),
-                 (40, 40, 45), 1)
-        cv2.line(img, (self.cx, self.cy - hl), (self.cx, self.cy + hl),
-                 (40, 40, 45), 1)
+    def _draw_canvas_crosshair(self, img: np.ndarray, ss: int = 1) -> None:
+        h, w = img.shape[:2]
+        cx, cy = self.cx * ss, self.cy * ss
+        hl = min(w, h) // 2
+        thickness = max(1, ss // 2)
+        cv2.line(img, (cx - hl, cy), (cx + hl, cy),
+                 (40, 40, 45), thickness, cv2.LINE_AA)
+        cv2.line(img, (cx, cy - hl), (cx, cy + hl),
+                 (40, 40, 45), thickness, cv2.LINE_AA)
 
     def _draw_shot_trace(
         self, img: np.ndarray, trace: ShotTrace,

--- a/core/target_renderer.py
+++ b/core/target_renderer.py
@@ -188,9 +188,6 @@ class TargetRenderer:
         if not mark_offsets:
             self._draw_canvas_crosshair(img)
 
-        approach_r = self.radius_to_px(self.target_cfg["rings_mm"][-1] * 2.0)
-        self._draw_dotted_circle(img, self.cx, self.cy, approach_r,
-                                 colour=(50, 50, 60))
         return img
 
     def _draw_rings(
@@ -198,16 +195,30 @@ class TargetRenderer:
         rings: list, scores: list, label: bool,
     ) -> None:
         n_rings = len(rings)
+        # The "bull" is the lighter-coloured central disc. Targets that
+        # carry an explicit ``bull_dia_mm`` use it directly; everything
+        # else falls back to the historical heuristic of treating the
+        # outer four rings as the dark surround. A bull diameter of 0
+        # means there is no bull — the whole card is dark.
+        bull_dia = self.target_cfg.get("bull_dia_mm")
+        if bull_dia is None:
+            bull_cutoff = n_rings - 4
+            in_bull = lambda i: i < bull_cutoff  # noqa: E731
+        else:
+            limit = float(bull_dia) + 1e-6
+            in_bull = lambda i: rings[i] * 2 <= limit  # noqa: E731
+
         for i in reversed(range(n_rings)):
             r = self.radius_to_px(rings[i])
-            fill = (15, 15, 15) if i >= n_rings - 4 else (240, 240, 240)
+            light = in_bull(i)
+            fill = (240, 240, 240) if light else (15, 15, 15)
             cv2.circle(img, (ocx, ocy), r, fill, -1)
             cv2.circle(img, (ocx, ocy), r, C_RING_OUTER, 1)
             if not label or i >= n_rings - 1:
                 continue
             score = scores[i]
             text = str(int(score)) if score == int(score) else str(score)
-            colour = (200, 200, 200) if i >= n_rings - 4 else (80, 80, 80)
+            colour = (80, 80, 80) if light else (200, 200, 200)
             mid_r = (rings[i] + (rings[i - 1] if i > 0 else 0)) / 2
             lx = int(ocx + mid_r * self.scale * 0.6)
             cv2.putText(img, text, (lx, ocy + 4),
@@ -221,19 +232,6 @@ class TargetRenderer:
                  (40, 40, 45), 1)
         cv2.line(img, (self.cx, self.cy - hl), (self.cx, self.cy + hl),
                  (40, 40, 45), 1)
-
-    @staticmethod
-    def _draw_dotted_circle(
-        img: np.ndarray, cx: int, cy: int, radius: int,
-        colour: Tuple[int, int, int] = (50, 50, 60), n_dashes: int = 48,
-    ) -> None:
-        for i in range(0, n_dashes, 2):
-            a1 = 2 * np.pi * i / n_dashes
-            a2 = 2 * np.pi * (i + 1) / n_dashes
-            for a in np.linspace(a1, a2, 4):
-                px = int(cx + radius * np.cos(a))
-                py = int(cy + radius * np.sin(a))
-                cv2.circle(img, (px, py), 1, colour, -1)
 
     def _draw_shot_trace(
         self, img: np.ndarray, trace: ShotTrace,

--- a/core/tracker.py
+++ b/core/tracker.py
@@ -1,56 +1,107 @@
-"""
-core/tracker.py
-ArUco marker tracking — computes where the camera is aimed relative to the
-target centre, expressed in millimetres on the target face.
+"""ArUco-based aim tracking and shot scoring.
 
-Layout expected on the printed A4 sheet:
-    Marker IDs:
-        0 ── top-left
-        1 ── top-right
-        2 ── bottom-right
-        3 ── bottom-left
+A printed sheet carries four (or six, or eight) ArUco markers at known
+positions. Each frame we:
 
-The four markers define the corners of a known rectangle (the "board").
-We use a homography from detected marker corners → known board coordinates
-to map the image centre (i.e. where the camera is pointing) into real-world
-mm coordinates relative to the target centre.
+1. Detect the markers in the camera image.
+2. Solve a homography from image pixels to board millimetres.
+3. Map the image centre - i.e. where the camera is pointing - through
+   that homography to get the aim point relative to the target centre.
+
+If markers are briefly lost, the most recent homography is reused for a
+short window so the aim point does not jitter to the centre on every
+dropped frame.
 """
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
 
 import cv2
 import numpy as np
-from dataclasses import dataclass
-from typing import Optional, Tuple, List
 
 
-# ── Data classes ─────────────────────────────────────────────────────────────
+# Marker IDs 0-3 form the corners; 4-5 add the left/right edge midpoints
+# for 6-marker layouts; 6-7 add top/bottom for 8-marker layouts.
+_MARKER_LAYOUTS = {
+    4: [0, 1, 2, 3],
+    6: [0, 1, 2, 3, 4, 5],
+    8: [0, 1, 2, 3, 4, 5, 6, 7],
+}
+
 
 @dataclass
 class TrackFrame:
-    """Result of processing one video frame."""
-    aim_mm: Optional[Tuple[float, float]] = None   # (x, y) mm from target centre
-    aim_px: Optional[Tuple[int, int]] = None        # pixel location of aim on DISPLAY image
+    """Tracking output for one camera frame."""
+    aim_mm: Optional[Tuple[float, float]] = None
+    aim_px: Optional[Tuple[int, int]] = None
     markers_found: int = 0
-    frame_display: Optional[np.ndarray] = None      # annotated frame for display
+    frame_display: Optional[np.ndarray] = None
     homography: Optional[np.ndarray] = None
-    quality: float = 0.0                            # 0-1 tracking quality
+    quality: float = 0.0
 
 
-# ── Constants ─────────────────────────────────────────────────────────────────
-
-MARKER_IDS = [0, 1, 2, 3]   # TL, TR, BR, BL
+def _build_board_corners(
+    board_w: float, board_h: float, marker: float, margin: float,
+) -> dict:
+    """Return the board-space (mm) corners for every supported marker ID."""
+    m, mg = marker, margin
+    bw, bh = board_w, board_h
+    return {
+        # Corners (TL, TR, BR, BL).
+        0: np.array([[mg, mg], [mg + m, mg], [mg + m, mg + m], [mg, mg + m]],
+                    dtype=np.float32),
+        1: np.array([[bw - mg - m, mg], [bw - mg, mg],
+                     [bw - mg, mg + m], [bw - mg - m, mg + m]],
+                    dtype=np.float32),
+        2: np.array([[bw - mg - m, bh - mg - m], [bw - mg, bh - mg - m],
+                     [bw - mg, bh - mg], [bw - mg - m, bh - mg]],
+                    dtype=np.float32),
+        3: np.array([[mg, bh - mg - m], [mg + m, bh - mg - m],
+                     [mg + m, bh - mg], [mg, bh - mg]],
+                    dtype=np.float32),
+        # Left and right edge midpoints (6-marker layout).
+        4: np.array([[mg, bh / 2 - m / 2], [mg + m, bh / 2 - m / 2],
+                     [mg + m, bh / 2 + m / 2], [mg, bh / 2 + m / 2]],
+                    dtype=np.float32),
+        5: np.array([[bw - mg - m, bh / 2 - m / 2],
+                     [bw - mg, bh / 2 - m / 2],
+                     [bw - mg, bh / 2 + m / 2],
+                     [bw - mg - m, bh / 2 + m / 2]],
+                    dtype=np.float32),
+        # Top and bottom edge midpoints (8-marker layout).
+        6: np.array([[bw / 2 - m / 2, mg], [bw / 2 + m / 2, mg],
+                     [bw / 2 + m / 2, mg + m], [bw / 2 - m / 2, mg + m]],
+                    dtype=np.float32),
+        7: np.array([[bw / 2 - m / 2, bh - mg - m],
+                     [bw / 2 + m / 2, bh - mg - m],
+                     [bw / 2 + m / 2, bh - mg],
+                     [bw / 2 - m / 2, bh - mg]],
+                    dtype=np.float32),
+    }
 
 
 class ArucoTracker:
-    """
-    Tracks the aim point using four ArUco markers arranged around a target.
+    """Track the aim point against a printed multi-marker board.
 
-    Parameters
-    ----------
-    board_width_mm  : real-world width of the marker board (outer edges of markers), mm
-    board_height_mm : real-world height of the marker board, mm
-    marker_size_mm  : printed size of each individual marker, mm
-    aruco_dict_name : cv2.aruco dictionary constant name string
+    Args:
+        board_width_mm: Real-world width of the printed sheet (mm).
+        board_height_mm: Real-world height of the printed sheet (mm).
+        marker_size_mm: Size of each printed ArUco marker (mm).
+        aruco_dict_name: Name of the ``cv2.aruco`` dictionary, e.g.
+            ``'DICT_4X4_50'``.
+        margin_mm: Distance from sheet edge to marker corner (mm).
+        use_clahe: Apply CLAHE contrast enhancement before detection.
+        clahe_clip: CLAHE clip limit (higher is more aggressive).
+        marker_count: Number of markers on the sheet (``4``, ``6`` or ``8``).
+        brightness_target: Mean brightness target for software gain
+            normalisation, used before CLAHE.
     """
+
+    MAX_HOMOGRAPHY_AGE = 5
+    """Frames a stale homography may be reused after detection drops out."""
 
     def __init__(
         self,
@@ -68,113 +119,65 @@ class ArucoTracker:
         self.board_height_mm = board_height_mm
         self.marker_size_mm = marker_size_mm
         self.margin_mm = margin_mm
+        self.use_clahe = use_clahe
+        self.brightness_target = float(brightness_target)
 
-        # Build ArUco detector
         dict_id = getattr(cv2.aruco, aruco_dict_name, cv2.aruco.DICT_4X4_50)
         self.aruco_dict = cv2.aruco.getPredefinedDictionary(dict_id)
         self.detector_params = cv2.aruco.DetectorParameters()
-        self.detector_params.cornerRefinementMethod = cv2.aruco.CORNER_REFINE_SUBPIX
-        self.detector = cv2.aruco.ArucoDetector(self.aruco_dict, self.detector_params)
+        self.detector_params.cornerRefinementMethod = (
+            cv2.aruco.CORNER_REFINE_SUBPIX)
+        self.detector = cv2.aruco.ArucoDetector(
+            self.aruco_dict, self.detector_params)
 
-        # CLAHE — Contrast Limited Adaptive Histogram Equalisation.
-        # Dramatically improves marker detection under uneven indoor lighting
-        # with negligible performance cost (~2ms per frame at 480p).
-        self.use_clahe = use_clahe
-        self.brightness_target = float(brightness_target)
         self._clahe = cv2.createCLAHE(
             clipLimit=float(clahe_clip), tileGridSize=(8, 8))
 
-        # Known corners of each marker in board-space (mm, origin = board TL)
-        # Order within each marker: TL, TR, BR, BL
-        m = marker_size_mm
-        mg = margin_mm
-        bw = board_width_mm
-        bh = board_height_mm
+        all_corners = _build_board_corners(
+            board_width_mm, board_height_mm, marker_size_mm, margin_mm)
+        active = _MARKER_LAYOUTS.get(marker_count, _MARKER_LAYOUTS[4])
+        self._board_corners = {k: all_corners[k] for k in active}
 
-        # Board corners for each marker ID — extended for 4/6/8 marker layouts.
-        # IDs 0-3: corners (TL, TR, BR, BL)
-        # IDs 4-5: left and right edge midpoints (6-marker layout)
-        # IDs 6-7: top and bottom edge midpoints (8-marker layout)
-        self._board_corners = {
-            0: np.array([[mg,       mg      ], [mg+m,    mg      ], [mg+m,    mg+m   ], [mg,      mg+m   ]], dtype=np.float32),
-            1: np.array([[bw-mg-m,  mg      ], [bw-mg,   mg      ], [bw-mg,   mg+m   ], [bw-mg-m, mg+m   ]], dtype=np.float32),
-            2: np.array([[bw-mg-m,  bh-mg-m ], [bw-mg,   bh-mg-m], [bw-mg,   bh-mg  ], [bw-mg-m, bh-mg  ]], dtype=np.float32),
-            3: np.array([[mg,       bh-mg-m ], [mg+m,    bh-mg-m], [mg+m,    bh-mg  ], [mg,      bh-mg  ]], dtype=np.float32),
-            # 6-marker: left and right edge midpoints (matches printed sheet)
-            4: np.array([[mg,       bh/2-m/2], [mg+m,    bh/2-m/2], [mg+m,    bh/2+m/2], [mg,      bh/2+m/2]], dtype=np.float32),
-            5: np.array([[bw-mg-m,  bh/2-m/2], [bw-mg,   bh/2-m/2], [bw-mg,   bh/2+m/2], [bw-mg-m, bh/2+m/2]], dtype=np.float32),
-            # 8-marker: top and bottom edge midpoints (matches printed sheet)
-            6: np.array([[bw/2-m/2, mg      ], [bw/2+m/2, mg      ], [bw/2+m/2, mg+m   ], [bw/2-m/2, mg+m  ]], dtype=np.float32),
-            7: np.array([[bw/2-m/2, bh-mg-m ], [bw/2+m/2, bh-mg-m], [bw/2+m/2, bh-mg  ], [bw/2-m/2, bh-mg ]], dtype=np.float32),
-        }
-        # Restrict to the active marker count
-        active_ids = {4: [0,1,2,3], 6: [0,1,2,3,4,5], 8: [0,1,2,3,4,5,6,7]}
-        keep = active_ids.get(marker_count, [0,1,2,3])
-        self._board_corners = {k: v for k, v in self._board_corners.items() if k in keep}
-
-        # Target centre in board-space (mm) — exactly the centre of the board
-        self.target_centre_mm = np.array([bw / 2, bh / 2], dtype=np.float32)
+        self.target_centre_mm = np.array(
+            [board_width_mm / 2, board_height_mm / 2], dtype=np.float32)
 
         self._last_homography: Optional[np.ndarray] = None
         self._homography_age: int = 0
-        self.MAX_HOMOGRAPHY_AGE = 5   # frames we'll reuse a stale homography
-
-    # ── Public API ────────────────────────────────────────────────────────────
-
-    def _make_empty_result(self) -> "TrackFrame":
-        r = TrackFrame()
-        return r
 
     def process_frame(self, frame: np.ndarray) -> TrackFrame:
+        """Run detection on one BGR frame and return the resulting state."""
         result = TrackFrame()
         result.frame_display = frame.copy()
 
-        # Pre-process: greyscale → software gain normalisation → CLAHE
-        # Gain normalisation scales brightness to a fixed target regardless of
-        # ambient light changes (clouds, time of day). Operates entirely in
-        # Python — no driver cooperation needed.
-        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-        if self.use_clahe:
-            mean = float(np.mean(gray))
-            if mean > 1.0:
-                scale = self.brightness_target / mean
-                gray = np.clip(gray.astype(np.float32) * scale,
-                               0, 255).astype(np.uint8)
-            gray = self._clahe.apply(gray)
-        corners, ids, rejected = self.detector.detectMarkers(gray)
+        gray = self._preprocess(frame)
+        corners, ids, _ = self.detector.detectMarkers(gray)
 
         if ids is None or len(ids) == 0:
-            result.markers_found = 0
             self._homography_age += 1
             self._try_reuse_homography(result, frame)
             return result
 
-        # Flatten id array
         ids_flat = ids.flatten()
         result.markers_found = len(ids_flat)
-
-        # Draw detected markers
         cv2.aruco.drawDetectedMarkers(result.frame_display, corners, ids)
 
-        # Build point correspondences: image pixel → board mm
         img_pts: List[np.ndarray] = []
         brd_pts: List[np.ndarray] = []
-
         for i, mid in enumerate(ids_flat):
             if mid in self._board_corners:
-                img_pts.append(corners[i][0])          # shape (4,2)
+                img_pts.append(corners[i][0])
                 brd_pts.append(self._board_corners[mid])
 
-        if len(img_pts) < 1:
+        if not img_pts:
             self._homography_age += 1
             self._try_reuse_homography(result, frame)
             return result
 
-        img_pts_all = np.concatenate(img_pts, axis=0)   # (N*4, 2)
-        brd_pts_all = np.concatenate(brd_pts, axis=0)
-
-        H, mask = cv2.findHomography(img_pts_all, brd_pts_all, cv2.RANSAC, 5.0)
-
+        H, _ = cv2.findHomography(
+            np.concatenate(img_pts, axis=0),
+            np.concatenate(brd_pts, axis=0),
+            cv2.RANSAC, 5.0,
+        )
         if H is None:
             self._homography_age += 1
             self._try_reuse_homography(result, frame)
@@ -184,125 +187,127 @@ class ArucoTracker:
         self._homography_age = 0
         result.homography = H
         result.quality = min(1.0, len(img_pts) / len(self._board_corners))
-
         self._compute_aim(result, frame)
         return result
 
-    # ── Private helpers ───────────────────────────────────────────────────────
+    def _preprocess(self, frame: np.ndarray) -> np.ndarray:
+        """Greyscale, software gain normalisation, then CLAHE."""
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        if not self.use_clahe:
+            return gray
+        mean = float(np.mean(gray))
+        if mean > 1.0:
+            scale = self.brightness_target / mean
+            gray = np.clip(
+                gray.astype(np.float32) * scale, 0, 255).astype(np.uint8)
+        return self._clahe.apply(gray)
 
-    def _try_reuse_homography(self, result: TrackFrame, frame: np.ndarray):
-        if self._last_homography is not None and self._homography_age <= self.MAX_HOMOGRAPHY_AGE:
-            result.homography = self._last_homography
-            result.quality = max(0.1, 0.5 - self._homography_age * 0.1)
-            self._compute_aim(result, frame)
+    def _try_reuse_homography(
+        self, result: TrackFrame, frame: np.ndarray,
+    ) -> None:
+        if self._last_homography is None:
+            return
+        if self._homography_age > self.MAX_HOMOGRAPHY_AGE:
+            return
+        result.homography = self._last_homography
+        result.quality = max(0.1, 0.5 - self._homography_age * 0.1)
+        self._compute_aim(result, frame)
 
-    def _compute_aim(self, result: TrackFrame, frame: np.ndarray):
+    def _compute_aim(
+        self, result: TrackFrame, frame: np.ndarray,
+    ) -> None:
         H = result.homography
         if H is None:
             return
 
         h, w = frame.shape[:2]
         img_centre = np.array([[[w / 2, h / 2]]], dtype=np.float32)
-
-        # Map image centre → board coordinates (mm)
         board_pt = cv2.perspectiveTransform(img_centre, H)[0][0]
 
-        # Convert to mm offset from target centre
-        aim_mm = (
+        result.aim_mm = (
             float(board_pt[0] - self.target_centre_mm[0]),
             float(board_pt[1] - self.target_centre_mm[1]),
         )
-        result.aim_mm = aim_mm
-
-        # Also store pixel coordinates of aim (image centre)
         result.aim_px = (int(w / 2), int(h / 2))
 
-        # Draw crosshair on display frame
-        cx, cy = int(w / 2), int(h / 2)
-        color = (0, 255, 0) if result.quality > 0.5 else (0, 165, 255)
-        cv2.line(result.frame_display, (cx - 20, cy), (cx + 20, cy), color, 2)
-        cv2.line(result.frame_display, (cx, cy - 20), (cx, cy + 20), color, 2)
-        cv2.circle(result.frame_display, (cx, cy), 8, color, 1)
+        cx, cy = result.aim_px
+        colour = (0, 255, 0) if result.quality > 0.5 else (0, 165, 255)
+        cv2.line(result.frame_display,
+                 (cx - 20, cy), (cx + 20, cy), colour, 2)
+        cv2.line(result.frame_display,
+                 (cx, cy - 20), (cx, cy + 20), colour, 2)
+        cv2.circle(result.frame_display, (cx, cy), 8, colour, 1)
 
-        # Annotate aim coords
-        txt = f"Aim: ({aim_mm[0]:+.1f}, {aim_mm[1]:+.1f}) mm"
-        cv2.putText(result.frame_display, txt, (10, h - 10),
+        text = f"Aim: ({result.aim_mm[0]:+.1f}, {result.aim_mm[1]:+.1f}) mm"
+        cv2.putText(result.frame_display, text, (10, h - 10),
                     cv2.FONT_HERSHEY_SIMPLEX, 0.5, (200, 200, 200), 1)
 
 
-# ── Scoring ────────────────────────────────────────────────────────────────────
+def _nearest_mark(
+    aim_mm: Tuple[float, float], mark_offsets: list,
+) -> Tuple[int, Tuple[float, float]]:
+    """Return ``(index, local_aim)`` for the nearest mark."""
+    best_idx = 0
+    best_local = aim_mm
+    best_dist = float("inf")
+    for idx, (mx, my) in enumerate(mark_offsets):
+        dx = aim_mm[0] - mx
+        dy = aim_mm[1] - my
+        dist = math.sqrt(dx * dx + dy * dy)
+        if dist < best_dist:
+            best_dist = dist
+            best_idx = idx
+            best_local = (dx, dy)
+    return best_idx, best_local
+
 
 def score_shot(
-    aim_mm: tuple,
+    aim_mm: Tuple[float, float],
     scoring_radius_mm: float,
     decimal: bool = False,
-    mark_offsets: list = None,
-) -> tuple:
+    mark_offsets: Optional[list] = None,
+) -> Tuple[float, int, int]:
+    """Score a shot purely from geometry.
+
+    Args:
+        aim_mm: Aim position ``(x, y)`` in mm relative to sheet centre.
+        scoring_radius_mm: ``card_radius + calibre_radius``.
+        decimal: ``True`` for 99 ISSF decimal bands; ``False`` for 10
+            integer bands.
+        mark_offsets: Optional list of mark centres for multi-mark
+            targets. When provided, the shot is assigned to the nearest
+            mark and scored relative to that mark's centre.
+
+    Returns:
+        ``(score, band_index, mark_index)``. A miss returns
+        ``(0.0, -1, mark_index)``. ``mark_index`` is always ``0`` for
+        single-mark targets.
     """
-    Score a shot purely from geometry.
-
-    aim_mm            : (x, y) in mm from sheet centre.
-    scoring_radius_mm : R = card_radius + calibre_radius.
-    decimal           : 99 bands (10.9->1.0) if True; 10 bands (10->1) if False.
-    mark_offsets      : list of (x_mm, y_mm) mark centres for multi-mark targets.
-                        If None, scores relative to (0,0) — single-mark behaviour
-                        unchanged. If multiple marks, assigns shot to nearest mark
-                        (Option C) and scores relative to that mark centre.
-
-    Returns (score, band_index, mark_index).
-    mark_index is always 0 for single-mark targets.
-    score=0.0, band=-1, mark_index=0 for a complete miss.
-    """
-    import math as _math
-
-    # Multi-mark: find nearest mark centre
     if mark_offsets and len(mark_offsets) > 1:
-        best_dist  = float("inf")
-        best_mark  = 0
-        best_local = aim_mm
-        for idx, (mx, my) in enumerate(mark_offsets):
-            dx = aim_mm[0] - mx
-            dy = aim_mm[1] - my
-            d  = _math.sqrt(dx*dx + dy*dy)
-            if d < best_dist:
-                best_dist  = d
-                best_mark  = idx
-                best_local = (dx, dy)
-        aim_local = best_local
-        mark_idx  = best_mark
+        mark_idx, aim_local = _nearest_mark(aim_mm, mark_offsets)
     else:
-        aim_local = aim_mm
-        mark_idx  = 0
+        mark_idx, aim_local = 0, aim_mm
 
-    aim_r = _math.sqrt(aim_local[0]**2 + aim_local[1]**2)
-
+    aim_r = math.sqrt(aim_local[0] ** 2 + aim_local[1] ** 2)
     if aim_r > scoring_radius_mm:
         return 0.0, -1, mark_idx
 
     if decimal:
         n_bands = 99
-        step    = 9.9 / 98
-        band_w  = scoring_radius_mm / n_bands
-        band_n  = min(int(aim_r / band_w), n_bands - 1)
-        score   = round(10.9 - band_n * step, 1)
-        return score, band_n, mark_idx
-    else:
-        n_bands = 10
-        band_w  = scoring_radius_mm / n_bands
-        band_n  = min(int(aim_r / band_w), n_bands - 1)
-        score   = float(10 - band_n)
-        return score, band_n, mark_idx
+        step = 9.9 / 98
+        band = min(int(aim_r / (scoring_radius_mm / n_bands)), n_bands - 1)
+        return round(10.9 - band * step, 1), band, mark_idx
 
-def aim_to_display(aim_mm, target_cfg, display_size_px):
-    """
-    Convert aim_mm (x,y) offset from target centre into pixel coordinates
-    on the target display canvas.
+    n_bands = 10
+    band = min(int(aim_r / (scoring_radius_mm / n_bands)), n_bands - 1)
+    return float(10 - band), band, mark_idx
 
-    display_size_px: (width, height) of the target display area
-    """
+
+def aim_to_display(
+    aim_mm: Tuple[float, float], target_cfg: dict, display_size_px: tuple,
+) -> Tuple[int, int]:
+    """Convert an aim offset (mm) to canvas pixels for the target view."""
     dw, dh = display_size_px
-    scale = min(dw, dh) / target_cfg["diameter_mm"]  # px per mm
+    scale = min(dw, dh) / target_cfg["diameter_mm"]
     cx, cy = dw / 2, dh / 2
-    px = int(cx + aim_mm[0] * scale)
-    py = int(cy + aim_mm[1] * scale)
-    return px, py
+    return int(cx + aim_mm[0] * scale), int(cy + aim_mm[1] * scale)

--- a/main.py
+++ b/main.py
@@ -1,8 +1,8 @@
-"""
-Splatt2 — DIY Target Shooting Trainer
-Entry point with crash logging.
-"""
+"""Application entry point with crash logging."""
 
+from __future__ import annotations
+
+import datetime
 import os
 import shutil
 import sys
@@ -13,30 +13,37 @@ if _BASE not in sys.path:
     sys.path.insert(0, _BASE)
 
 
-def _migrate_legacy_crash_log(dst: str) -> None:
-    """Copy a pre-1.2 crash log from next to main.py into the user dir."""
-    if os.path.exists(dst):
+def _migrate_legacy_crash_log(destination: str) -> None:
+    """Copy any pre-1.2 crash log next to ``main.py`` into the user dir."""
+    if os.path.exists(destination):
         return
     legacy = os.path.join(_BASE, "splatt2_crash.log")
-    if os.path.isfile(legacy):
-        try:
-            os.makedirs(os.path.dirname(dst), exist_ok=True)
-            shutil.copy2(legacy, dst)
-        except OSError:
-            pass
+    if not os.path.isfile(legacy):
+        return
+    try:
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        shutil.copy2(legacy, destination)
+    except OSError:
+        pass
 
 
 def _write_crash_log(exc_text: str):
-    import datetime
+    """Append an exception traceback to the user crash log.
+
+    Returns the log path on success, or ``None`` if the log could not be
+    written.
+    """
     from core.paths import crash_log_path
 
     path = str(crash_log_path())
     _migrate_legacy_crash_log(path)
     try:
         with open(path, "a", encoding="utf-8") as f:
-            f.write(f"\n{'=' * 60}\n")
-            f.write(f"Crash at {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
-            f.write(f"{'=' * 60}\n")
+            timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            divider = "=" * 60
+            f.write(f"\n{divider}\n")
+            f.write(f"Crash at {timestamp}\n")
+            f.write(f"{divider}\n")
             f.write(exc_text)
             f.write("\n")
         return path
@@ -44,11 +51,33 @@ def _write_crash_log(exc_text: str):
         return None
 
 
-def main():
+def _show_crash_dialog(exc_text: str, log_path) -> None:
+    """Best-effort Tk dialog showing the crash message and log location."""
+    try:
+        import tkinter as tk
+        from tkinter import messagebox
+    except Exception:
+        return
+
+    try:
+        root = tk.Tk()
+        root.withdraw()
+        message = f"Splatt2 crashed unexpectedly.\n\n{exc_text[:400]}\n\n"
+        if log_path:
+            message += (
+                f"Full details saved to:\n{log_path}\n\n"
+                "Please include this file when reporting the issue."
+            )
+        messagebox.showerror("Splatt2 — Crash", message)
+        root.destroy()
+    except Exception:
+        pass
+
+
+def main() -> None:
     print("Starting Splatt2...")
     from ui.app import SplattApp
-    app = SplattApp()
-    app.run()
+    SplattApp().run()
 
 
 if __name__ == "__main__":
@@ -58,18 +87,5 @@ if __name__ == "__main__":
         exc_text = traceback.format_exc()
         print(exc_text)
         log_path = _write_crash_log(exc_text)
-
-        try:
-            import tkinter as tk
-            from tkinter import messagebox
-            root = tk.Tk()
-            root.withdraw()
-            msg = f"Splatt2 crashed unexpectedly.\n\n{exc_text[:400]}\n\n"
-            if log_path:
-                msg += f"Full details saved to:\n{log_path}\n\nPlease include this file when reporting the issue."
-            messagebox.showerror("Splatt2 — Crash", msg)
-            root.destroy()
-        except Exception:
-            pass
-
+        _show_crash_dialog(exc_text, log_path)
         sys.exit(1)

--- a/main.py
+++ b/main.py
@@ -3,31 +3,44 @@ Splatt2 — DIY Target Shooting Trainer
 Entry point with crash logging.
 """
 
-import sys
 import os
+import shutil
+import sys
 import traceback
 
-# Ensure the project directory is on the path
 _BASE = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, _BASE)
+if _BASE not in sys.path:
+    sys.path.insert(0, _BASE)
 
 
-def _crash_log_path() -> str:
-    return os.path.join(_BASE, "splatt2_crash.log")
+def _migrate_legacy_crash_log(dst: str) -> None:
+    """Copy a pre-1.2 crash log from next to main.py into the user dir."""
+    if os.path.exists(dst):
+        return
+    legacy = os.path.join(_BASE, "splatt2_crash.log")
+    if os.path.isfile(legacy):
+        try:
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            shutil.copy2(legacy, dst)
+        except OSError:
+            pass
 
 
 def _write_crash_log(exc_text: str):
     import datetime
-    path = _crash_log_path()
+    from core.paths import crash_log_path
+
+    path = str(crash_log_path())
+    _migrate_legacy_crash_log(path)
     try:
         with open(path, "a", encoding="utf-8") as f:
-            f.write(f"\n{'='*60}\n")
+            f.write(f"\n{'=' * 60}\n")
             f.write(f"Crash at {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
-            f.write(f"{'='*60}\n")
+            f.write(f"{'=' * 60}\n")
             f.write(exc_text)
             f.write("\n")
         return path
-    except Exception:
+    except OSError:
         return None
 
 

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,5 @@
+# Build-time dependencies for packaging Splatt2.
+# Install alongside requirements.txt:
+#   pip install -r requirements.txt -r requirements-build.txt
+
+pyinstaller>=6.20

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Tkinter UI for Splatt2."""

--- a/ui/app.py
+++ b/ui/app.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import math
 import os
 import queue
+import sys
 import threading
 import time
 import tkinter as tk
@@ -59,6 +60,22 @@ _ROTATION_FLAGS = {
     180: cv2.ROTATE_180,
     270: cv2.ROTATE_90_COUNTERCLOCKWISE,
 }
+
+
+def _camera_backend() -> int:
+    """OpenCV capture backend appropriate for the current platform.
+
+    Hardcoding ``CAP_DSHOW`` (DirectShow, Windows-only) on macOS or
+    Linux causes ``cv2.VideoCapture`` to hang or block while OpenCV
+    walks through fallbacks, which freezes the UI thread.
+    """
+    if sys.platform == "darwin":
+        return cv2.CAP_AVFOUNDATION
+    if sys.platform.startswith("linux"):
+        return cv2.CAP_V4L2
+    if sys.platform == "win32":
+        return cv2.CAP_DSHOW
+    return cv2.CAP_ANY
 
 
 class _FpsCounter:
@@ -126,6 +143,17 @@ class SplattApp:
         self._cap = None
         self._running = False
         self._paused = False
+        # Set whenever no camera loop is running. The loop clears it
+        # while alive and sets it again on exit, after releasing the
+        # capture device. Re-opens block on this event so the new
+        # session never races the previous one's teardown.
+        self._loop_done = threading.Event()
+        self._loop_done.set()
+        # Coalescing flag: the camera worker sets this to request a UI
+        # repaint, the Tk thread clears it once it has rendered. This
+        # avoids piling up per-frame ``root.after`` calls when the UI
+        # cannot keep pace with capture.
+        self._cam_refresh_pending = False
         self._shot_queue = queue.Queue()
         self._current_aim_mm = None
         self._raw_aim_prev = None
@@ -181,7 +209,11 @@ class SplattApp:
         self._editor_show_dur = None
 
         self._build_window()
-        self.root.after(100, self._update_loop)
+        # Score, target trace and audio refreshes run on a slow timer
+        # so the UI thread is mostly idle and stays responsive to
+        # native events like dropdown clicks. Camera frame display is
+        # driven directly from the worker via ``_request_cam_refresh``.
+        self.root.after(100, self._tick_periodic)
         if self._first_run:
             self.root.after(300, self._show_first_run_wizard)
         self._editor_show_trace = tk.BooleanVar(value=True)
@@ -544,35 +576,48 @@ class SplattApp:
         """Apply the dark ttk + tk option-database theme to the root."""
         _apply_theme(self.root)
     def _scan_cameras(self):
+        """Probe available cameras off the UI thread.
+
+        On macOS each ``VideoCapture(idx, AVFOUNDATION)`` can block for
+        a second or more (permissions, device enumeration), so doing
+        this on the Tk thread freezes the entire app. The scan runs in
+        a daemon thread and posts results back via ``root.after``.
+        """
         self._cam_combo.config(state="disabled")
         self._cam_combo["values"] = ["Scanning..."]
         self._cam_var.set("Scanning...")
-        self.root.after(10, self._do_scan)
+        threading.Thread(target=self._scan_in_background,
+                         daemon=True).start()
 
-    @staticmethod
-    def _probe_camera(idx: int):
-        """Return ``(width, height)`` for the camera at ``idx`` if openable."""
-        cap = cv2.VideoCapture(idx, cv2.CAP_DSHOW)
-        try:
-            if not cap.isOpened():
-                return None
-            return (
-                int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)),
-                int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)),
-            )
-        finally:
-            cap.release()
+    def _scan_in_background(self) -> None:
+        """Probe camera indices until a gap suggests we're past the last one.
 
-    def _do_scan(self):
+        macOS exposes a dense index range, so two consecutive failures
+        is a reliable stop signal that avoids the noisy AVFoundation
+        "out of bounds" warnings. On Windows/Linux indices can be
+        sparse, so we still probe up to 8.
+        """
+        max_indices = 8
+        max_consecutive_misses = 8 if sys.platform != "darwin" else 2
+
         found = []
-        for i in range(8):
+        misses = 0
+        for i in range(max_indices):
             size = self._probe_camera(i)
-            if size is not None:
-                w, h = size
-                found.append((i, f"{i}: Camera {i}  ({w}x{h})"))
+            if size is None:
+                misses += 1
+                if misses >= max_consecutive_misses:
+                    break
+                continue
+            misses = 0
+            w, h = size
+            found.append((i, f"{i}: Camera {i}  ({w}x{h})"))
+
         if not found:
             found = [(i, f"{i}: Camera {i}") for i in range(4)]
+        self.root.after(0, self._apply_scan_results, found)
 
+    def _apply_scan_results(self, found: list) -> None:
         self._cam_entries = {label: idx for idx, label in found}
         labels = [label for _, label in found]
         self._cam_combo["values"] = labels
@@ -587,6 +632,20 @@ class SplattApp:
         elif labels:
             self._cam_var.set(labels[0])
 
+    @staticmethod
+    def _probe_camera(idx: int):
+        """Return ``(width, height)`` for the camera at ``idx`` if openable."""
+        cap = cv2.VideoCapture(idx, _camera_backend())
+        try:
+            if not cap.isOpened():
+                return None
+            return (
+                int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)),
+                int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)),
+            )
+        finally:
+            cap.release()
+
     def _on_cam_selected(self, event=None):
         lbl = self._cam_var.get()
         if hasattr(self, "_cam_entries") and lbl in self._cam_entries:
@@ -594,38 +653,71 @@ class SplattApp:
             save_config(self.cfg)
             if self._running:
                 self._stop_camera()
-                self.root.after(400, self._start_camera)
+                # The next _start_camera call waits on _loop_done in
+                # its background open thread, so no manual delay is
+                # needed.
+                self._start_camera()
 
     def _start_camera(self):
+        """Stop if running; otherwise open the camera off the UI thread.
+
+        Opening a ``VideoCapture`` on macOS can stall the calling
+        thread for over a second while AVFoundation negotiates with
+        the device. Doing it on the Tk thread freezes the entire UI,
+        so we kick the open into a worker and finish setup on the main
+        thread once the capture handle is ready.
+        """
         if self._running:
             self._stop_camera()
             return
 
+        self._set_status("Opening camera…", GOLD)
+        self._btn_cam.configure(state="disabled")
         idx = self.cfg.get("camera_index", 0)
+        threading.Thread(target=self._open_camera_in_background,
+                         args=(idx,), daemon=True).start()
+
+    def _open_camera_in_background(self, idx) -> None:
+        # Wait for any previous camera loop to fully tear down its
+        # device handle before grabbing the next one. Without this,
+        # AVFoundation can hand us a half-released handle that hangs.
+        self._loop_done.wait(timeout=5.0)
         cap = self._open_capture(idx)
+        self.root.after(0, self._finish_camera_open, idx, cap)
+
+    def _finish_camera_open(self, idx, cap) -> None:
+        self._btn_cam.configure(state="normal")
         if cap is None:
+            self._set_status("READY", TEXT_SEC)
             messagebox.showerror(
                 "Camera Error",
                 f"Cannot open camera {idx}. Try another index.")
             return
 
-        self._cap = cap
         target_fps = int(self.cfg.get("video_fps", 30))
         self._configure_capture(cap, target_fps)
         actual_fps = cap.get(cv2.CAP_PROP_FPS)
         self._camera_fps = actual_fps if actual_fps > 0 else target_fps
 
+        self._cap = cap
         self._running = True
+        self._loop_done.clear()
         self._btn_cam.configure(text="■  Stop Camera")
         _set_variant(self._btn_cam, "danger")
         self._set_status("LIVE", ACCENT)
         self.audio.start()
-        threading.Thread(target=self._camera_loop, daemon=True).start()
+        threading.Thread(target=self._camera_loop,
+                         args=(cap,), daemon=True).start()
 
     @staticmethod
     def _open_capture(idx: int):
-        """Open the camera, preferring DirectShow on Windows, then default."""
-        cap = cv2.VideoCapture(idx, cv2.CAP_DSHOW)
+        """Open the camera using the OS-appropriate backend.
+
+        Falls back to ``CAP_ANY`` so an unusual driver setup still
+        works, but the platform-specific backend is tried first to
+        avoid OpenCV's slow probe of unsupported backends.
+        """
+        cap = cv2.VideoCapture(idx, _camera_backend())
         if cap.isOpened():
             return cap
         cap = cv2.VideoCapture(idx)
@@ -655,20 +747,31 @@ class SplattApp:
                     cv2.VideoWriter.fourcc("Y", "U", "Y", "2"))
 
     def _stop_camera(self):
+        """Signal the camera loop to exit; the loop releases the cap.
+
+        Releasing the capture from the UI thread while the loop thread
+        is mid-``cap.read()`` deadlocks AVFoundation on macOS. The loop
+        owns the device handle for its lifetime and tears it down on
+        exit.
+        """
         self._running = False
         self.audio.stop()
-        if self._cap:
-            self._cap.release()
-            self._cap = None
         self._btn_cam.configure(text="▶  Start Camera")
         _set_variant(self._btn_cam, "accent")
         self._set_status("STOPPED", TEXT_DIM)
 
 
 
-    def _camera_loop(self):
-        """
-        Optimised camera loop:
+    def _camera_loop(self, cap):
+        """Drive frame capture, ArUco detection and UI publishing.
+
+        The loop owns ``cap`` for its entire lifetime: the UI thread
+        signals exit via ``self._running``, and the loop releases the
+        device on the way out before setting ``self._loop_done``. This
+        keeps device teardown on the same thread that reads from it,
+        avoiding the macOS deadlock where ``cap.release()`` from the
+        UI thread blocks while the loop is mid-``cap.read()``.
+
         - BUFFERSIZE=1 means cap.read() always returns the freshest frame
         - Frame is downscaled to max 480p for ArUco detection regardless of
           capture resolution — this is the single biggest speed gain
@@ -681,41 +784,50 @@ class SplattApp:
         detect_w, detect_h = 640, 480
         fps = _FpsCounter()
 
-        while self._running:
-            if not self._cap or not self._cap.isOpened():
-                break
-            ret, frame = self._cap.read()
-            if not ret:
-                time.sleep(0.005)
-                continue
+        try:
+            while self._running:
+                if not cap.isOpened():
+                    break
+                ret, frame = cap.read()
+                if not ret:
+                    time.sleep(0.005)
+                    continue
 
-            if self.cfg.get("flip_image"):
-                frame = cv2.flip(frame, self.cfg.get("flip_mode", -1))
-            rotation = _ROTATION_FLAGS.get(self._camera_rotation)
-            if rotation is not None:
-                frame = cv2.rotate(frame, rotation)
+                if self.cfg.get("flip_image"):
+                    frame = cv2.flip(frame, self.cfg.get("flip_mode", -1))
+                rotation = _ROTATION_FLAGS.get(self._camera_rotation)
+                if rotation is not None:
+                    frame = cv2.rotate(frame, rotation)
 
-            small = self._downscale_for_detection(frame, detect_w, detect_h)
-            if self._focus_active:
-                self._sharpness = self._measure_sharpness(small)
+                small = self._downscale_for_detection(frame, detect_w, detect_h)
+                if self._focus_active:
+                    self._sharpness = self._measure_sharpness(small)
 
-            result = self.tracker.process_frame(small)
-            self._tracking_quality = result.quality
-            self._current_markers_found = result.markers_found
+                result = self.tracker.process_frame(small)
+                self._tracking_quality = result.quality
+                self._current_markers_found = result.markers_found
 
-            if result.aim_mm is not None and not self._paused:
-                self._consume_aim(result)
+                if result.aim_mm is not None and not self._paused:
+                    self._consume_aim(result)
 
-            self._live_fps = fps.tick()
-            if self._focus_active:
-                self._update_sharpness_peak()
+                self._live_fps = fps.tick()
+                if self._focus_active:
+                    self._update_sharpness_peak()
 
-            ui_counter += 1
-            if not no_video and ui_counter >= ui_every:
-                self._publish_camera_frame(result.frame_display, self._live_fps)
-                ui_counter = 0
+                ui_counter += 1
+                if not no_video and ui_counter >= ui_every:
+                    self._publish_camera_frame(result.frame_display, self._live_fps)
+                    ui_counter = 0
 
-            self._drain_shot_queue()
+                self._drain_shot_queue()
+        finally:
+            try:
+                cap.release()
+            except Exception:
+                pass
+            if self._cap is cap:
+                self._cap = None
+            self._loop_done.set()
 
     def _downscale_for_detection(self, frame, max_w: int, max_h: int):
         """Resize ``frame`` so it fits within (max_w, max_h) for detection."""
@@ -768,6 +880,7 @@ class SplattApp:
                     cv2.FONT_HERSHEY_SIMPLEX, 0.45,
                     (80, 220, 80), 1, cv2.LINE_AA)
         self._latest_cam_frame = disp
+        self._request_cam_refresh()
 
     def _drain_shot_queue(self) -> None:
         """Process any queued audio triggers against the current aim."""
@@ -918,20 +1031,39 @@ class SplattApp:
             _set_toggle(self._btn_zero, False, accent_color=GOLD),
             self._set_status("ZEROED", ACCENT)
         ))
-    def _update_loop(self):
-        """Drive periodic UI refreshes.
+    def _tick_periodic(self):
+        """Slow timer for non-camera UI updates.
 
-        Live previews (camera frame, audio meter) run at ~30 Hz while
-        the camera is active. Score widgets and the shot log are only
-        refreshed when something has actually changed, which avoids
-        rebuilding the Text widget and 12 stat labels every tick.
+        The target render carries live shot traces and the active aim
+        crosshair, so it has to repaint while the camera is running.
+        Score widgets and the audio meter only need a few Hz to look
+        live. Polling at 10 Hz instead of 30 Hz frees the Tk thread to
+        process native events (dropdown clicks, menus, focus) without
+        contention from the GIL-heavy camera worker.
         """
         self._update_target_display()
         self._refresh_score_widgets_if_dirty()
         if self._running:
-            self._update_cam_display()
             self._update_audio_meter()
-        self.root.after(33, self._update_loop)
+        self.root.after(100, self._tick_periodic)
+
+    def _request_cam_refresh(self):
+        """Coalesced request to repaint the camera preview.
+
+        Called from the camera worker thread after each published
+        frame. ``after_idle`` runs the repaint on the Tk thread when
+        it next has spare time, and the pending flag prevents queuing
+        multiple repaints if frames arrive faster than Tk can draw.
+        """
+        if self._cam_refresh_pending or not self._running:
+            return
+        self._cam_refresh_pending = True
+        self.root.after_idle(self._do_cam_refresh)
+
+    def _do_cam_refresh(self):
+        self._cam_refresh_pending = False
+        if self._running:
+            self._update_cam_display()
 
     def _refresh_score_widgets_if_dirty(self):
         """Only repaint the score panel when its inputs have changed."""
@@ -1536,7 +1668,7 @@ class SplattApp:
         if cam_changed and self._running:
             self._set_status("Restarting camera with new settings…", GOLD)
             self._stop_camera()
-            self.root.after(600, self._start_camera)
+            self._start_camera()
 
     def _apply_session_cfg(self):
         """Push config values into the live session object."""
@@ -1856,8 +1988,9 @@ class SplattApp:
     def _on_close(self):
         self._running = False
         self.audio.stop()
-        if self._cap:
-            self._cap.release()
+        # Let the camera loop release the capture itself; releasing
+        # from the UI thread can deadlock on macOS.
+        self._loop_done.wait(timeout=2.0)
         # Close live writer first
         self.session.end_series()
         # Save full JSON archive
@@ -3200,22 +3333,21 @@ class SettingsDialog(tk.Toplevel):
             idx = 0
         self._cam_caps_lbl.config(text="Probing…")
         self.update()
-        import cv2 as _cv2
-        cap = _cv2.VideoCapture(idx, _cv2.CAP_DSHOW)
+        cap = cv2.VideoCapture(idx, _camera_backend())
         if not cap.isOpened():
-            cap = _cv2.VideoCapture(idx)
+            cap = cv2.VideoCapture(idx)
         if not cap.isOpened():
             self._cam_caps_lbl.config(text="Not found")
             return
         results = []
         for (w, h) in [(480,360),(640,480),(1280,720),(1920,1080)]:
-            cap.set(_cv2.CAP_PROP_FRAME_WIDTH,  w)
-            cap.set(_cv2.CAP_PROP_FRAME_HEIGHT, h)
+            cap.set(cv2.CAP_PROP_FRAME_WIDTH,  w)
+            cap.set(cv2.CAP_PROP_FRAME_HEIGHT, h)
             for fps_try in (60, 30):
-                cap.set(_cv2.CAP_PROP_FPS, fps_try)
-                aw = int(cap.get(_cv2.CAP_PROP_FRAME_WIDTH))
-                ah = int(cap.get(_cv2.CAP_PROP_FRAME_HEIGHT))
-                af = cap.get(_cv2.CAP_PROP_FPS)
+                cap.set(cv2.CAP_PROP_FPS, fps_try)
+                aw = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+                ah = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+                af = cap.get(cv2.CAP_PROP_FPS)
                 if aw == w and ah == h:
                     results.append(f"{w}×{h}@{af:.0f}")
                     break

--- a/ui/app.py
+++ b/ui/app.py
@@ -2551,9 +2551,10 @@ class SettingsDialog(tk.Toplevel):
         self.configure(bg=BG_DARK)
         self.resizable(True, True)
         self.grab_set()
-        self.geometry("560x680")
         self.minsize(480, 500)
+        self._tab_inners: list[tk.Frame] = []
         self._build()
+        self.after(60, self._size_to_content)
     def _build(self):
         # Fixed button row at BOTTOM (always visible)
         btn_row = tk.Frame(self, bg=BG_DARK)
@@ -2605,8 +2606,30 @@ class SettingsDialog(tk.Toplevel):
                          c.unbind_all("<MouseWheel>"))
 
             builder(inner)
+            self._tab_inners.append(inner)
             # Force scroll region now that content is populated
             self.after(50, _refresh)
+
+    def _size_to_content(self) -> None:
+        """Resize the dialog so the tallest tab fits without scrolling."""
+        if not self._tab_inners:
+            return
+        for inner in self._tab_inners:
+            inner.update_idletasks()
+        content_w = max(inner.winfo_reqwidth() for inner in self._tab_inners)
+        content_h = max(inner.winfo_reqheight() for inner in self._tab_inners)
+
+        # Add the chrome: notebook tabs, button row, scrollbar, padding.
+        chrome_w = 60
+        chrome_h = 110
+
+        # Cap to 90% of the screen so the dialog never overflows it.
+        max_w = int(self.winfo_screenwidth() * 0.9)
+        max_h = int(self.winfo_screenheight() * 0.9)
+
+        width = min(max_w, max(self.winfo_reqwidth(), content_w + chrome_w))
+        height = min(max_h, max(self.winfo_reqheight(), content_h + chrome_h))
+        self.geometry(f"{width}x{height}")
     def _row(self, parent, label, widget_fn):
         r = tk.Frame(parent, bg=BG_DARK)
         r.pack(fill="x", padx=12, pady=4)

--- a/ui/app.py
+++ b/ui/app.py
@@ -548,29 +548,42 @@ class SplattApp:
         self._cam_var.set("Scanning...")
         self.root.after(10, self._do_scan)
 
+    @staticmethod
+    def _probe_camera(idx: int):
+        """Return ``(width, height)`` for the camera at ``idx`` if openable."""
+        cap = cv2.VideoCapture(idx, cv2.CAP_DSHOW)
+        try:
+            if not cap.isOpened():
+                return None
+            return (
+                int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)),
+                int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)),
+            )
+        finally:
+            cap.release()
+
     def _do_scan(self):
         found = []
         for i in range(8):
-            cap = cv2.VideoCapture(i, cv2.CAP_DSHOW)
-            if cap.isOpened():
-                w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-                h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+            size = self._probe_camera(i)
+            if size is not None:
+                w, h = size
                 found.append((i, f"{i}: Camera {i}  ({w}x{h})"))
-                cap.release()
-            else:
-                cap.release()
         if not found:
             found = [(i, f"{i}: Camera {i}") for i in range(4)]
-        self._cam_entries = {lbl: idx for idx, lbl in found}
-        labels = [lbl for _, lbl in found]
+
+        self._cam_entries = {label: idx for idx, label in found}
+        labels = [label for _, label in found]
         self._cam_combo["values"] = labels
         self._cam_combo.config(state="readonly")
-        cur = self.cfg.get("camera_index", 0)
-        for lbl in labels:
-            if lbl.startswith(str(cur) + ":"):
-                self._cam_var.set(lbl)
-                return
-        if labels:
+
+        current = self.cfg.get("camera_index", 0)
+        prefix = f"{current}:"
+        match = next((label for label in labels
+                      if label.startswith(prefix)), None)
+        if match is not None:
+            self._cam_var.set(match)
+        elif labels:
             self._cam_var.set(labels[0])
 
     def _on_cam_selected(self, event=None):

--- a/ui/app.py
+++ b/ui/app.py
@@ -586,41 +586,58 @@ class SplattApp:
         if self._running:
             self._stop_camera()
             return
+
         idx = self.cfg.get("camera_index", 0)
-        self._cap = cv2.VideoCapture(idx, cv2.CAP_DSHOW)
-        if not self._cap.isOpened():
-            self._cap = cv2.VideoCapture(idx)
-        if not self._cap.isOpened():
-            messagebox.showerror("Camera Error",
-                                  f"Cannot open camera {idx}. Try another index.")
+        cap = self._open_capture(idx)
+        if cap is None:
+            messagebox.showerror(
+                "Camera Error",
+                f"Cannot open camera {idx}. Try another index.")
             return
-        w = int(self.cfg.get("video_width", 640))
-        h = int(self.cfg.get("video_height", 480))
+
+        self._cap = cap
         target_fps = int(self.cfg.get("video_fps", 30))
-        self._cap.set(cv2.CAP_PROP_FRAME_WIDTH,  w)
-        self._cap.set(cv2.CAP_PROP_FRAME_HEIGHT, h)
-        self._cap.set(cv2.CAP_PROP_FPS, target_fps)
-        # Pixel format — MJPEG prevents static-scene frame rate throttling
-        _fmt = self.cfg.get("camera_pixel_format", "Auto")
-        if _fmt == "MJPEG":
-            _accepted = self._cap.set(cv2.CAP_PROP_FOURCC,
-                                      cv2.VideoWriter.fourcc('M','J','P','G'))
-            _rb = int(self._cap.get(cv2.CAP_PROP_FOURCC))
-            _rb_str = ''.join([chr((_rb >> (8*i)) & 0xFF) for i in range(4)])
-            print(f"[Camera] MJPEG requested — fourcc readback: {_rb_str!r}")
-        elif _fmt == "YUY2":
-            self._cap.set(cv2.CAP_PROP_FOURCC,
-                          cv2.VideoWriter.fourcc('Y','U','Y','2'))
-        # Minimise buffer — always get freshest frame, never queue up stale ones
-        self._cap.set(cv2.CAP_PROP_BUFFERSIZE, 1)
-        actual_fps = self._cap.get(cv2.CAP_PROP_FPS)
+        self._configure_capture(cap, target_fps)
+        actual_fps = cap.get(cv2.CAP_PROP_FPS)
         self._camera_fps = actual_fps if actual_fps > 0 else target_fps
+
         self._running = True
         self._btn_cam.config(text="■  Stop Camera", bg=ACCENT2, fg=BG_DARK)
         self._set_status("LIVE", ACCENT)
         self.audio.start()
         threading.Thread(target=self._camera_loop, daemon=True).start()
-        # _update_loop is already running (started at init); no need to restart
+
+    @staticmethod
+    def _open_capture(idx: int):
+        """Open the camera, preferring DirectShow on Windows, then default."""
+        cap = cv2.VideoCapture(idx, cv2.CAP_DSHOW)
+        if cap.isOpened():
+            return cap
+        cap = cv2.VideoCapture(idx)
+        return cap if cap.isOpened() else None
+
+    def _configure_capture(self, cap, target_fps: int) -> None:
+        """Apply resolution, FPS, pixel format and buffer settings."""
+        cap.set(cv2.CAP_PROP_FRAME_WIDTH, int(self.cfg.get("video_width", 640)))
+        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, int(self.cfg.get("video_height", 480)))
+        cap.set(cv2.CAP_PROP_FPS, target_fps)
+        self._apply_pixel_format(cap)
+        # BUFFERSIZE=1 ensures cap.read() always returns the freshest frame
+        # rather than queueing up stale ones.
+        cap.set(cv2.CAP_PROP_BUFFERSIZE, 1)
+
+    def _apply_pixel_format(self, cap) -> None:
+        """Optionally request MJPEG/YUY2 to avoid static-scene FPS throttling."""
+        fmt = self.cfg.get("camera_pixel_format", "Auto")
+        if fmt == "MJPEG":
+            cap.set(cv2.CAP_PROP_FOURCC,
+                    cv2.VideoWriter.fourcc("M", "J", "P", "G"))
+            readback = int(cap.get(cv2.CAP_PROP_FOURCC))
+            chars = "".join(chr((readback >> (8 * i)) & 0xFF) for i in range(4))
+            print(f"[Camera] MJPEG requested — fourcc readback: {chars!r}")
+        elif fmt == "YUY2":
+            cap.set(cv2.CAP_PROP_FOURCC,
+                    cv2.VideoWriter.fourcc("Y", "U", "Y", "2"))
 
     def _stop_camera(self):
         self._running = False

--- a/ui/app.py
+++ b/ui/app.py
@@ -209,10 +209,12 @@ class SplattApp:
                                      bg=BG_MID, fg=TEXT_SEC, font=FH)
         self._session_lbl.pack(side="left", padx=8)
         self._status_lbl = tk.Label(top, text="● READY", bg=BG_MID,
-                                    fg=TEXT_SEC, font=("Consolas", 9))
+                                    fg=TEXT_SEC, font=("Consolas", 9),
+                                    width=60, anchor="e")
         self._status_lbl.pack(side="right", padx=16)
         self._tracking_lbl = tk.Label(top, text="TRACKING: —", bg=BG_MID,
-                                      fg=TEXT_DIM, font=("Consolas", 9))
+                                      fg=TEXT_DIM, font=("Consolas", 9),
+                                      width=14, anchor="e")
         self._tracking_lbl.pack(side="right", padx=8)
         _mk_btn(top, "📋  Series", self._open_series_tab).pack(
             side="right", padx=4, pady=8)
@@ -917,14 +919,43 @@ class SplattApp:
             self._set_status("ZEROED", ACCENT)
         ))
     def _update_loop(self):
-        # Target display and scores run always (even without camera)
-        # so colour changes / shot edits reflect immediately
+        """Drive periodic UI refreshes.
+
+        Live previews (camera frame, audio meter) run at ~30 Hz while
+        the camera is active. Score widgets and the shot log are only
+        refreshed when something has actually changed, which avoids
+        rebuilding the Text widget and 12 stat labels every tick.
+        """
         self._update_target_display()
-        self._update_scores()
+        self._refresh_score_widgets_if_dirty()
         if self._running:
             self._update_cam_display()
             self._update_audio_meter()
         self.root.after(33, self._update_loop)
+
+    def _refresh_score_widgets_if_dirty(self):
+        """Only repaint the score panel when its inputs have changed."""
+        ses = self.session
+        ss = ses.series_shots
+        sel_idx = (self._selected_shot.index
+                   if self._selected_shot is not None else None)
+        # Per-shot mutable bits (score, deletion, flags) feed into the
+        # signature so edits show up without rebuilding every frame.
+        shot_state = tuple(
+            (s.index, s.score, s.deleted, s.match_shot,
+             s.favourite, s.missed, bool(s.comments))
+            for s in ss
+        )
+        sig = (
+            shot_state, ses.current_series, sel_idx,
+            self._on_target_status, self._in_approach_zone,
+            self._show_bbox_shots, self._show_bbox_acp,
+            getattr(self, "_last_shot_info", None),
+        )
+        if sig == getattr(self, "_score_sig", None):
+            return
+        self._score_sig = sig
+        self._update_scores()
 
     def _update_cam_display(self):
         frame = self._latest_cam_frame
@@ -982,11 +1013,12 @@ class SplattApp:
         fading = self.session.get_fading_trace()
         fade_age = self.session.fading_age_s
 
-        # In editor mode pass only selected shots
+        # In editor mode, only render shots whose checkbox is ticked.
         if self._in_series_editor and self._editor_show_trace is not None:
+            shot_vars = self._editor_shot_vars
             sel_shots = [s for s in self.session.shots
-                         if self._editor_shot_vars.get(s.index,
-                             tk.BooleanVar(value=True)).get()]
+                         if s.index not in shot_vars
+                         or shot_vars[s.index].get()]
             show_tr  = self._editor_show_trace.get()
             show_acp = self._editor_show_acp.get()
         else:
@@ -1062,11 +1094,15 @@ class SplattApp:
         bbox = ses.bbox_shots_mm
         self._stat_labels["bbox_s"].config(
             text=f"{bbox[0]:.1f}×{bbox[1]:.1f}mm" if bbox and self._show_bbox_shots else "—")
-        acps = [s.aim_centrepoint for s in ss if s.aim_centrepoint]
-        if acps and self._show_bbox_acp:
-            ax = [a[0] for a in acps]; ay = [a[1] for a in acps]
-            self._stat_labels["bbox_a"].config(
-                text=f"{max(ax)-min(ax):.1f}×{max(ay)-min(ay):.1f}mm")
+        if self._show_bbox_acp:
+            acps = [s.aim_centrepoint for s in ss if s.aim_centrepoint]
+            if acps:
+                ax = [a[0] for a in acps]
+                ay = [a[1] for a in acps]
+                self._stat_labels["bbox_a"].config(
+                    text=f"{max(ax)-min(ax):.1f}×{max(ay)-min(ay):.1f}mm")
+            else:
+                self._stat_labels["bbox_a"].config(text="—")
         else:
             self._stat_labels["bbox_a"].config(text="—")
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -36,7 +36,12 @@ from ui.theme import (
     ACCENT, ACCENT2, BG_CARD, BG_DARK, BG_MID, BG_PANEL, BORDER, GOLD,
     TEXT_DIM, TEXT_PRI, TEXT_SEC,
     FB, FH, FL, FM, FS, FT,
+    apply_theme as _apply_theme,
     make_button as _mk_btn,
+    make_toggle_button as _mk_toggle,
+    make_chip_button as _mk_chip,
+    set_toggle_state as _set_toggle,
+    set_button_variant as _set_variant,
 )
 
 
@@ -182,13 +187,17 @@ class SplattApp:
         self._editor_show_trace = tk.BooleanVar(value=True)
         self._editor_show_acp = tk.BooleanVar(value=True)
         self._editor_show_dur = tk.BooleanVar(value=True)
-        self._apply_styles()
     def _build_window(self):
         self.root = tk.Tk()
         self.root.title(f"SPLATT2 v{VERSION} — Target Shooting Trainer")
         self.root.configure(bg=BG_DARK)
         self.root.minsize(1200, 750)
         self.root.geometry("1440x840")
+
+        # Theme must be applied before any widgets are created so the
+        # option database affects them. ttk.Style settings are applied
+        # to the root and inherited by widgets in any toplevel.
+        self._apply_styles()
 
         # Top bar
         top = tk.Frame(self.root, bg=BG_MID, height=46)
@@ -255,10 +264,9 @@ class SplattApp:
         self._focus_active = False
         ff_btn = tk.Frame(parent, bg=BG_PANEL)
         ff_btn.pack(fill="x", padx=6, pady=(0, 2))
-        self._btn_focus = tk.Button(ff_btn, text="◎ Focus assist: OFF",
-                                     command=self._toggle_focus_assist,
-                                     bg=BG_CARD, fg=TEXT_DIM, font=FL,
-                                     relief="flat", padx=6, pady=2, cursor="hand2")
+        self._btn_focus = _mk_toggle(ff_btn, "◎ Focus assist: OFF",
+                                     self._focus_active,
+                                     self._toggle_focus_assist)
         self._btn_focus.pack(side="left")
 
         self._focus_frame = tk.Frame(parent, bg=BG_PANEL)
@@ -372,51 +380,45 @@ class SplattApp:
             v.pack(side="right")
             self._stat_labels[key] = v
 
-        # Display toggles — two rows so nothing overflows 270px panel
-        def _tog_state(text_on, text_off, state):
-            return (text_on if state else text_off,
-                    ACCENT if state else BG_CARD,
-                    BG_DARK if state else TEXT_SEC)
-
-        def _tbtn(parent, text_on, text_off, state, cmd):
-            t, bg, fg = _tog_state(text_on, text_off, state)
-            return tk.Button(parent, text=t, bg=bg, fg=fg, font=FL,
-                             relief="flat", bd=0, padx=6, pady=4,
-                             cursor="hand2", command=cmd,
-                             activebackground=ACCENT, activeforeground=BG_DARK)
+        # Display toggles — two rows so nothing overflows 270px panel.
+        # Toggles use a clearly-distinct active style so it's obvious
+        # whether each overlay is on.
+        BLUE = "#4f8fff"
 
         # Row 1: ACP  Shots Box  ACP Box
         row1 = tk.Frame(parent, bg=BG_PANEL)
         row1.pack(fill="x", padx=6, pady=(2, 1))
-        self._btn_acp = _tbtn(row1, "◈ ACP", "◈ ACP",
-                               self._show_acp, self._toggle_acp)
-        self._btn_acp.config(bg=ACCENT if self._show_acp else BG_CARD,
-                              fg=BG_DARK if self._show_acp else TEXT_SEC)
+        self._btn_acp = _mk_toggle(row1, "◈ ACP", self._show_acp,
+                                   self._toggle_acp)
         self._btn_acp.pack(side="left", padx=(0, 2))
-        self._btn_bbox_s = _tbtn(row1, "⊡ Shots", "⊡ Shots",
-                                  self._show_bbox_shots, self._toggle_bbox_shots)
-        if self._show_bbox_shots:
-            self._btn_bbox_s.config(bg=ACCENT, fg=BG_DARK)
+        self._btn_bbox_s = _mk_toggle(row1, "⊡ Shots", self._show_bbox_shots,
+                                      self._toggle_bbox_shots,
+                                      accent_color=BLUE)
         self._btn_bbox_s.pack(side="left", padx=(0, 2))
-        self._btn_bbox_a = _tbtn(row1, "◇ ACP Box", "◇ ACP Box",
-                                  self._show_bbox_acp, self._toggle_bbox_acp)
-        if self._show_bbox_acp:
-            self._btn_bbox_a.config(bg=ACCENT, fg=BG_DARK)
+        self._btn_bbox_a = _mk_toggle(row1, "◇ ACP Box", self._show_bbox_acp,
+                                      self._toggle_bbox_acp,
+                                      accent_color=BLUE)
         self._btn_bbox_a.pack(side="left")
 
         # Row 2: Dot  Group circle
         row2 = tk.Frame(parent, bg=BG_PANEL)
         row2.pack(fill="x", padx=6, pady=(0, 3))
-        self._btn_dot = _tbtn(row2, "● Dot", "● Dot",
-                               self._shot_dot_only, self._toggle_dot_mode)
-        if self._shot_dot_only:
-            self._btn_dot.config(bg=ACCENT, fg=BG_DARK)
+        self._btn_dot = _mk_toggle(row2, "● Dot", self._shot_dot_only,
+                                   self._toggle_dot_mode)
         self._btn_dot.pack(side="left", padx=(0, 2))
-        self._btn_group = _tbtn(row2, "○ Group", "○ Group",
-                                 self._show_group, self._toggle_group)
-        if self._show_group:
-            self._btn_group.config(bg=ACCENT, fg=BG_DARK)
+        self._btn_group = _mk_toggle(row2, "○ Group", self._show_group,
+                                     self._toggle_group,
+                                     accent_color=GOLD)
         self._btn_group.pack(side="left")
+
+        # Remember each toggle's accent so updates use the same colour.
+        self._toggle_accents = {
+            id(self._btn_acp): ACCENT,
+            id(self._btn_bbox_s): BLUE,
+            id(self._btn_bbox_a): BLUE,
+            id(self._btn_dot): ACCENT,
+            id(self._btn_group): GOLD,
+        }
 
         # Shot log
         lc = tk.Frame(parent, bg=BG_CARD)
@@ -461,20 +463,23 @@ class SplattApp:
             side="left", padx=(8, 3), pady=5)
         self._btn_pause = parent.winfo_children()[-1]
 
-        self._btn_zero = _mk_btn(parent, "◎  Zero", self._toggle_zero_mode)
+        self._btn_zero = _mk_toggle(parent, "◎  Zero", False,
+                                    self._toggle_zero_mode,
+                                    accent_color=GOLD)
         self._btn_zero.pack(side="left", padx=(0, 2), pady=5)
-        self._btn_fine_zero = _mk_btn(parent, "⊕  Fine Zero",
-                                       self._toggle_fine_zero_mode)
+        self._btn_fine_zero = _mk_toggle(parent, "⊕  Fine Zero", False,
+                                         self._toggle_fine_zero_mode,
+                                         accent_color=GOLD)
         self._btn_fine_zero.pack(side="left", padx=(0, 3), pady=5)
 
-        self._btn_decimal = _mk_btn(
+        self._btn_decimal = _mk_toggle(
             parent, "DEC ON" if self._decimal_scoring else "DEC OFF",
-            self._toggle_decimal_scoring)
+            self._decimal_scoring, self._toggle_decimal_scoring)
         self._btn_decimal.pack(side="left", padx=(0, 8), pady=5)
 
         rot = self.cfg.get("camera_rotation", 0)
-        self._btn_rotate = _mk_btn(
-            parent, f"↻ {rot}°", self._cycle_rotation)
+        self._btn_rotate = _mk_toggle(
+            parent, f"↻ {rot}°", rot != 0, self._cycle_rotation)
         self._btn_rotate.pack(side="left", padx=(0, 8), pady=5)
 
         # Zoom slider
@@ -534,18 +539,8 @@ class SplattApp:
                  bg=BG_MID, fg=TEXT_DIM, font=FL).pack(side="right", padx=10)
 
     def _apply_styles(self):
-        s = ttk.Style()
-        s.theme_use("clam")
-        for name, col in [("Quality", ACCENT), ("Audio", "#4f8fff")]:
-            s.configure(f"{name}.Horizontal.TProgressbar",
-                        troughcolor=BG_DARK, background=col,
-                        bordercolor=BG_DARK, lightcolor=col, darkcolor=col)
-        s.configure("TScale", background=BG_MID, troughcolor=BG_CARD)
-        s.configure("TNotebook", background=BG_DARK, borderwidth=0)
-        s.configure("TNotebook.Tab", background=BG_CARD, foreground=TEXT_SEC,
-                    padding=[8, 3])
-        s.map("TNotebook.Tab", background=[("selected", BG_PANEL)],
-              foreground=[("selected", ACCENT)])
+        """Apply the dark ttk + tk option-database theme to the root."""
+        _apply_theme(self.root)
     def _scan_cameras(self):
         self._cam_combo.config(state="disabled")
         self._cam_combo["values"] = ["Scanning..."]
@@ -619,7 +614,8 @@ class SplattApp:
         self._camera_fps = actual_fps if actual_fps > 0 else target_fps
 
         self._running = True
-        self._btn_cam.config(text="■  Stop Camera", bg=ACCENT2, fg=BG_DARK)
+        self._btn_cam.configure(text="■  Stop Camera")
+        _set_variant(self._btn_cam, "danger")
         self._set_status("LIVE", ACCENT)
         self.audio.start()
         threading.Thread(target=self._camera_loop, daemon=True).start()
@@ -662,7 +658,8 @@ class SplattApp:
         if self._cap:
             self._cap.release()
             self._cap = None
-        self._btn_cam.config(text="▶  Start Camera", bg=BG_CARD, fg=TEXT_SEC)
+        self._btn_cam.configure(text="▶  Start Camera")
+        _set_variant(self._btn_cam, "accent")
         self._set_status("STOPPED", TEXT_DIM)
 
 
@@ -915,7 +912,8 @@ class SplattApp:
         self._last_shot_fired_time = time.time()
         self._save_zero_offset()
         self.root.after(0, lambda: (
-            self._btn_zero.config(text="◎  Zero", bg=BG_CARD, fg=TEXT_SEC),
+            self._btn_zero.configure(text="◎  Zero"),
+            _set_toggle(self._btn_zero, False, accent_color=GOLD),
             self._set_status("ZEROED", ACCENT)
         ))
     def _update_loop(self):
@@ -1165,12 +1163,13 @@ class SplattApp:
             self._sharpness        = 0.0
             self._focus_frame.pack(fill="x", padx=6, pady=(0, 2),
                                    after=self._btn_focus.master)
-            self._btn_focus.config(text="◎ Focus assist: ON", fg=ACCENT, bg=BG_MID)
+            self._btn_focus.config(text="◎ Focus assist: ON")
         else:
             self._focus_frame.pack_forget()
             self._sharpness_var.set(0)
             self._focus_lbl.config(text="—", fg=TEXT_DIM)
-            self._btn_focus.config(text="◎ Focus assist: OFF", fg=TEXT_DIM, bg=BG_CARD)
+            self._btn_focus.config(text="◎ Focus assist: OFF")
+        _set_toggle(self._btn_focus, self._focus_active)
 
     def _on_zoom_change(self, val=None):
         """Zoom slider changed — rebuild renderer at new scale."""
@@ -1196,10 +1195,12 @@ class SplattApp:
         self.audio.pause(self._paused)
         btn = self._btn_pause
         if self._paused:
-            btn.config(text="▶  Resume", bg=GOLD, fg=BG_DARK)
+            btn.configure(text="▶  Resume")
+            _set_variant(btn, "warn")
             self._set_status("PAUSED", GOLD)
         else:
-            btn.config(text="❙❙  Pause", bg=BG_CARD, fg=TEXT_SEC)
+            btn.configure(text="❙❙  Pause")
+            _set_variant(btn, "default")
             self._set_status("LIVE" if self._running else "READY", ACCENT)
 
     def _save_zero_offset(self):
@@ -1214,13 +1215,15 @@ class SplattApp:
             return
         self._zero_mode = not self._zero_mode
         if self._zero_mode:
-            self._btn_zero.config(text="◎  Waiting…", bg=GOLD, fg=BG_DARK)
+            self._btn_zero.config(text="◎  Waiting…")
+            _set_toggle(self._btn_zero, True, accent_color=GOLD)
             self._set_status("ZERO MODE — fire one shot", GOLD)
             # Cancel fine-zero if active
             if self._fine_zero_mode:
                 self._cancel_fine_zero()
         else:
-            self._btn_zero.config(text="◎  Zero", bg=BG_CARD, fg=TEXT_SEC)
+            self._btn_zero.config(text="◎  Zero")
+            _set_toggle(self._btn_zero, False, accent_color=GOLD)
             self._set_status("LIVE" if self._running else "READY", ACCENT)
 
     def _toggle_fine_zero_mode(self):
@@ -1229,22 +1232,23 @@ class SplattApp:
             self._cancel_fine_zero()
             return
         self._fine_zero_mode = True
-        self._btn_fine_zero.config(
-            text="⊕  Click centre…", bg=GOLD, fg=BG_DARK)
+        self._btn_fine_zero.config(text="⊕  Click centre…")
+        _set_toggle(self._btn_fine_zero, True, accent_color=GOLD)
         self._set_status(
             "FINE ZERO — click your shot group centre on the target", GOLD)
         # Cancel normal zero mode if active
         if self._zero_mode:
             self._zero_mode = False
-            self._btn_zero.config(text="◎  Zero", bg=BG_CARD, fg=TEXT_SEC)
+            self._btn_zero.config(text="◎  Zero")
+            _set_toggle(self._btn_zero, False, accent_color=GOLD)
         # Bind click on target canvas
         self._tgt_canvas.bind("<Button-1>", self._on_fine_zero_click)
         self._tgt_canvas.config(cursor="crosshair")
 
     def _cancel_fine_zero(self):
         self._fine_zero_mode = False
-        self._btn_fine_zero.config(
-            text="⊕  Fine Zero", bg=BG_CARD, fg=TEXT_SEC)
+        self._btn_fine_zero.config(text="⊕  Fine Zero")
+        _set_toggle(self._btn_fine_zero, False, accent_color=GOLD)
         self._tgt_canvas.unbind("<Button-1>")
         self._tgt_canvas.config(cursor="")
         self._set_status("LIVE" if self._running else "READY", ACCENT)
@@ -1276,9 +1280,8 @@ class SplattApp:
         self.cfg["decimal_scoring"] = self._decimal_scoring
         save_config(self.cfg)
         self._btn_decimal.config(
-            text="DEC ON"  if self._decimal_scoring else "DEC OFF",
-            bg=ACCENT if self._decimal_scoring else BG_CARD,
-            fg=BG_DARK if self._decimal_scoring else TEXT_SEC)
+            text="DEC ON" if self._decimal_scoring else "DEC OFF")
+        _set_toggle(self._btn_decimal, self._decimal_scoring)
 
     def _cycle_rotation(self):
         """Cycle camera rotation: 0 → 90 → 180 → 270 → 0."""
@@ -1286,16 +1289,15 @@ class SplattApp:
         self.cfg["camera_rotation"] = self._camera_rotation
         save_config(self.cfg)
         if hasattr(self, "_btn_rotate"):
-            self._btn_rotate.config(text=f"↻ {self._camera_rotation}°",
-                                    bg=BG_CARD if self._camera_rotation == 0 else ACCENT,
-                                    fg=TEXT_SEC if self._camera_rotation == 0 else BG_DARK)
+            self._btn_rotate.config(text=f"↻ {self._camera_rotation}°")
+            _set_toggle(self._btn_rotate, self._camera_rotation != 0)
 
     def _set_toggle_button(self, button: tk.Button, active: bool) -> None:
         """Apply the standard accent/idle styling to a toggle button."""
-        button.config(
-            bg=ACCENT if active else BG_CARD,
-            fg=BG_DARK if active else TEXT_SEC,
-        )
+        accent = ACCENT
+        if hasattr(self, "_toggle_accents"):
+            accent = self._toggle_accents.get(id(button), ACCENT)
+        _set_toggle(button, active, accent_color=accent)
 
     def _toggle_acp(self):
         self._show_acp = not self._show_acp
@@ -1348,8 +1350,9 @@ class SplattApp:
                     "Series is active. Stop recording and finish?"):
                 self.session.end_series()
                 self._series_started = False
-                self._btn_start_series.config(
-                    text="▶  Start Series", bg=ACCENT, fg=BG_DARK)
+                self._btn_start_series.configure(
+                    text="▶  Start Series")
+                _set_variant(self._btn_start_series, "accent")
                 self._set_status("Series stopped — file saved", GOLD)
             return
 
@@ -1375,9 +1378,9 @@ class SplattApp:
             return
 
         self._series_started = True
-        self._btn_start_series.config(
-            text="■  Series Active — click to stop",
-            bg=ACCENT2, fg=BG_DARK)
+        self._btn_start_series.configure(
+            text="■  Series Active — click to stop")
+        _set_variant(self._btn_start_series, "danger")
         sn = self.session.current_series
         self._set_status(f"● REC  Series {sn} — recording to {os.path.basename(path)}", ACCENT2)
 
@@ -1385,8 +1388,8 @@ class SplattApp:
         self.session.clear_series()
         self._series_started = False
         if hasattr(self, '_btn_start_series'):
-            self._btn_start_series.config(
-                text="▶  Start Series", bg=ACCENT, fg=BG_DARK)
+            self._btn_start_series.configure(text="▶  Start Series")
+            _set_variant(self._btn_start_series, "accent")
         self._selected_shot = None
         self._highlighted_trace = None
         self._set_status("READY — press Start Series", TEXT_SEC)
@@ -1403,10 +1406,11 @@ class SplattApp:
             self._series_started = False
             self._in_approach_zone = False
             self._in_series_editor = False
-            self._btn_zero.config(text="◎  Zero", bg=BG_CARD, fg=TEXT_SEC)
+            self._btn_zero.configure(text="◎  Zero")
+            _set_toggle(self._btn_zero, False, accent_color=GOLD)
             if hasattr(self, '_btn_start_series'):
-                self._btn_start_series.config(
-                    text="▶  Start Series", bg=ACCENT, fg=BG_DARK)
+                self._btn_start_series.configure(text="▶  Start Series")
+                _set_variant(self._btn_start_series, "accent")
             self._last_shot_lbl.config(text="Last shot: —", fg=TEXT_SEC)
             self._set_status("READY — press Start Series", TEXT_SEC)
             self._exit_series_editor()
@@ -1484,11 +1488,8 @@ class SplattApp:
         self._fine_zero_mode = False
         if hasattr(self, "_btn_rotate"):
             rot = self._camera_rotation
-            self._btn_rotate.config(
-                text=f"↻ {rot}°",
-                bg=BG_CARD if rot == 0 else ACCENT,
-                fg=TEXT_SEC if rot == 0 else BG_DARK,
-            )
+            self._btn_rotate.configure(text=f"↻ {rot}°")
+            _set_toggle(self._btn_rotate, rot != 0)
 
         self._zero_offset = (
             float(self.cfg.get("zero_offset_x", 0.0)),
@@ -1536,8 +1537,8 @@ class SplattApp:
             self.session.end_series()
             self._series_started = False
             if hasattr(self, '_btn_start_series'):
-                self._btn_start_series.config(
-                    text="▶  Start Series", bg=ACCENT, fg=BG_DARK)
+                self._btn_start_series.configure(text="▶  Start Series")
+                _set_variant(self._btn_start_series, "accent")
         SeriesReviewWindow(self.root, self.session, self.cfg,
                            self.target_cfg,
                            on_next_series=self._start_next_series,
@@ -1648,12 +1649,8 @@ class SplattApp:
         def _save():
             shot.comments = var.get().strip()
             dlg.destroy()
-        tk.Button(bf, text="Save", command=_save,
-                  bg=ACCENT, fg=BG_DARK, font=("Segoe UI", 9),
-                  relief="flat", padx=10, pady=4).pack(side="right", padx=4)
-        tk.Button(bf, text="Cancel", command=dlg.destroy,
-                  bg=BG_CARD, fg=TEXT_SEC, font=("Segoe UI", 9),
-                  relief="flat", padx=10, pady=4).pack(side="right")
+        _mk_btn(bf, "Save", _save, accent=True).pack(side="right", padx=4)
+        _mk_btn(bf, "Cancel", dlg.destroy).pack(side="right")
 
     def _delete_shot(self, shot):
         if messagebox.askyesno("Delete", f"Delete shot #{shot.index}?"):
@@ -1670,8 +1667,8 @@ class SplattApp:
         self.session.end_series()
         self._series_started = False
         if hasattr(self, '_btn_start_series'):
-            self._btn_start_series.config(
-                text="▶  Start Series", bg=ACCENT, fg=BG_DARK)
+            self._btn_start_series.configure(text="▶  Start Series")
+            _set_variant(self._btn_start_series, "accent")
         # Enter review mode
         self._in_series_editor = True
         for w in self._score_panel_frame.winfo_children():
@@ -1694,8 +1691,8 @@ class SplattApp:
         self._build_score_panel(self._score_panel_frame)
         self._set_status("READY — press Start Series", TEXT_SEC)
         if hasattr(self, '_btn_start_series'):
-            self._btn_start_series.config(
-                text="▶  Start Series", bg=ACCENT, fg=BG_DARK)
+            self._btn_start_series.configure(text="▶  Start Series")
+            _set_variant(self._btn_start_series, "accent")
 
     def _exit_series_editor(self):
         self._in_series_editor = False
@@ -1714,11 +1711,8 @@ class SplattApp:
         def _tog_btn(p, text, var, col=ACCENT):
             def cb():
                 var.set(not var.get())
-                btn.config(bg=col if var.get() else BG_CARD,
-                           fg=BG_DARK if var.get() else TEXT_SEC)
-            btn = _mk_btn(p, text, cb)
-            btn.config(bg=col if var.get() else BG_CARD,
-                       fg=BG_DARK if var.get() else TEXT_SEC)
+                _set_toggle(btn, var.get(), accent_color=col)
+            btn = _mk_toggle(p, text, var.get(), cb, accent_color=col)
             return btn
 
         _tog_btn(tog, "Trace",   self._editor_show_trace).pack(side="left", padx=(0,2))
@@ -1913,9 +1907,8 @@ class SplattApp:
             dlg.destroy()
             self._set_status("Setup complete — print your marker sheet and start the camera!", ACCENT)
 
-        tk.Button(dlg, text="Let's go  ▶", command=_done,
-                  bg=ACCENT, fg=BG_DARK, font=("Segoe UI", 11, "bold"),
-                  relief="flat", padx=20, pady=8, cursor="hand2").pack(pady=(20, 4))
+        _go_btn = _mk_btn(dlg, "Let's go  ▶", _done, accent=True)
+        _go_btn.pack(pady=(20, 4))
 
         def _print_now():
             # Persist current wizard choices so the sheet uses the right
@@ -1929,10 +1922,7 @@ class SplattApp:
             self.target_cfg = TARGETS[self.cfg["target_key"]]
             MarkerSheetDialog(dlg, self.cfg)
 
-        tk.Button(dlg, text="🖨  Print marker sheet now",
-                  command=_print_now,
-                  bg=BG_CARD, fg=TEXT_PRI, font=("Segoe UI", 9),
-                  relief="flat", padx=12, pady=4, cursor="hand2").pack(pady=(0, 16))
+        _mk_btn(dlg, "🖨  Print marker sheet now", _print_now).pack(pady=(0, 16))
 
         # Prevent closing without completing
         dlg.protocol("WM_DELETE_WINDOW", _done)
@@ -1996,10 +1986,9 @@ class MarkerSheetDialog(tk.Toplevel):
         tk.Entry(r4, textvariable=self._mvar, width=6, bg=BG_CARD, fg=TEXT_PRI,
                  insertbackground=ACCENT, relief="flat", font=FM).pack(side="left")
         for sz in [25, 35, 40, 50]:
-            tk.Button(r4, text=str(sz),
-                      command=lambda v=sz: (self._mvar.set(str(v)), self._preview()),
-                      bg=BG_CARD, fg=TEXT_DIM, font=FL, relief="flat",
-                      padx=4, pady=2, cursor="hand2").pack(side="left", padx=2)
+            _mk_chip(r4, str(sz),
+                     lambda v=sz: (self._mvar.set(str(v)),
+                                   self._preview())).pack(side="left", padx=2)
         self._mvar.trace_add("write", lambda *_: self._preview())
 
         r5 = tk.Frame(parent, bg=BG_DARK); r5.pack(fill="x", **pad)
@@ -2016,11 +2005,9 @@ class MarkerSheetDialog(tk.Toplevel):
         self._sheet_calibre = tk.StringVar(
             value=str(self.cfg.get("scoring_calibre_mm", 4.5)))
         for label, val in [("4.5 (.177)", "4.5"), ("5.6 (.22)", "5.6")]:
-            tk.Button(r7, text=label,
-                      command=lambda v=val: (self._sheet_calibre.set(v),
-                                            self._preview()),
-                      bg=BG_CARD, fg=TEXT_DIM, font=FL, relief="flat",
-                      padx=4, pady=2, cursor="hand2").pack(side="left", padx=2)
+            _mk_chip(r7, label,
+                     lambda v=val: (self._sheet_calibre.set(v),
+                                    self._preview())).pack(side="left", padx=2)
         tk.Entry(r7, textvariable=self._sheet_calibre, width=5, bg=BG_CARD,
                  fg=TEXT_PRI, insertbackground=ACCENT, relief="flat",
                  font=FM).pack(side="left", padx=(4,0))
@@ -2061,12 +2048,8 @@ class MarkerSheetDialog(tk.Toplevel):
         self._info.pack(fill="x", padx=14, pady=8)
 
         bf = tk.Frame(parent, bg=BG_DARK); bf.pack(fill="x", padx=14, pady=(4, 14))
-        tk.Button(bf, text="Generate & Open", command=self._generate,
-                  bg=ACCENT, fg=BG_DARK, font=FB, relief="flat",
-                  padx=12, pady=6).pack(side="right", padx=4)
-        tk.Button(bf, text="Cancel", command=self.destroy,
-                  bg=BG_CARD, fg=TEXT_SEC, font=FB, relief="flat",
-                  padx=12, pady=6).pack(side="right", padx=4)
+        _mk_btn(bf, "Generate & Open", self._generate, accent=True).pack(side="right", padx=4)
+        _mk_btn(bf, "Cancel", self.destroy).pack(side="right", padx=4)
         self._preview()
 
     def _get(self):
@@ -2138,9 +2121,8 @@ class MarkerSheetDialog(tk.Toplevel):
                                            width=30, font=FL)
         self._c_mode_combo.pack(side="left", padx=(0,6))
         self._c_mode_combo.bind("<<ComboboxSelected>>", self._on_creator_mode)
-        tk.Button(top, text="Delete", command=self._delete_target,
-                  bg=ACCENT2, fg=BG_DARK, font=FL, relief="flat",
-                  padx=6, pady=3, cursor="hand2").pack(side="left")
+        _del_btn = _mk_btn(top, "Delete", self._delete_target, danger=True)
+        _del_btn.pack(side="left")
         meta = tk.Frame(parent, bg=BG_DARK); meta.pack(fill="x", **pad)
 
         def _field(frame, label, var, width=20):
@@ -2182,11 +2164,9 @@ class MarkerSheetDialog(tk.Toplevel):
                  fg=TEXT_PRI, insertbackground=ACCENT, relief="flat",
                  font=FM).pack(side="left")
         for lbl, val in [("4.5",4.5),("5.6",5.6)]:
-            tk.Button(r_cal, text=lbl,
-                      command=lambda v=val: (self._c_calibre.set(str(v)),
-                                            self._update_creator_preview()),
-                      bg=BG_CARD, fg=TEXT_DIM, font=FL, relief="flat",
-                      padx=4, pady=1, cursor="hand2").pack(side="left", padx=2)
+            _mk_chip(r_cal, lbl,
+                     lambda v=val: (self._c_calibre.set(str(v)),
+                                    self._update_creator_preview())).pack(side="left", padx=2)
         tk.Label(r_cal, text="  Card dia (mm):", bg=BG_DARK, fg=TEXT_SEC,
                  font=FB).pack(side="left", padx=(8,0))
         tk.Entry(r_cal, textvariable=self._c_card, width=6, bg=BG_CARD,
@@ -2219,9 +2199,7 @@ class MarkerSheetDialog(tk.Toplevel):
                                    font=FM, anchor="w")
         self._c_status.pack(fill="x", padx=10)
         bf = tk.Frame(parent, bg=BG_DARK); bf.pack(fill="x", padx=10, pady=(2,8))
-        tk.Button(bf, text="Save Target", command=self._save_target,
-                  bg=ACCENT, fg=BG_DARK, font=FB, relief="flat",
-                  padx=12, pady=5, cursor="hand2").pack(side="right")
+        _mk_btn(bf, "Save Target", self._save_target, accent=True).pack(side="right")
 
         self._update_creator_preview()
 
@@ -2580,15 +2558,10 @@ class SettingsDialog(tk.Toplevel):
         # Fixed button row at BOTTOM (always visible)
         btn_row = tk.Frame(self, bg=BG_DARK)
         btn_row.pack(side="bottom", fill="x", padx=8, pady=8)
-        tk.Button(btn_row, text="Apply & Close", command=self._apply_and_close,
-                  bg=ACCENT, fg=BG_DARK, font=FB, relief="flat",
-                  padx=12, pady=7).pack(side="right", padx=4)
-        tk.Button(btn_row, text="Apply", command=self._apply,
-                  bg=BG_CARD, fg=ACCENT, font=FB, relief="flat",
-                  padx=12, pady=7).pack(side="right", padx=4)
-        tk.Button(btn_row, text="Cancel", command=self.destroy,
-                  bg=BG_CARD, fg=TEXT_SEC, font=FB, relief="flat",
-                  padx=12, pady=7).pack(side="right", padx=4)
+        _mk_btn(btn_row, "Apply & Close", self._apply_and_close,
+                accent=True).pack(side="right", padx=4)
+        _mk_btn(btn_row, "Apply", self._apply).pack(side="right", padx=4)
+        _mk_btn(btn_row, "Cancel", self.destroy).pack(side="right", padx=4)
         self._status_lbl = tk.Label(btn_row, text="", bg=BG_DARK,
                                      fg=ACCENT, font=FL)
         self._status_lbl.pack(side="left", padx=8)
@@ -2680,11 +2653,10 @@ class SettingsDialog(tk.Toplevel):
                  fg=TEXT_PRI, insertbackground=ACCENT, relief="flat", font=FM).pack(side="left")
         for lbl, (w, h) in [("480×360",(480,360)),("640×480",(640,480)),
                              ("1280×720",(1280,720))]:
-            tk.Button(r, text=lbl,
-                      command=lambda w=w,h=h: (self._v_video_width.set(str(w)),
-                                               self._v_video_height.set(str(h))),
-                      bg=BG_CARD, fg=TEXT_DIM, font=FL, relief="flat",
-                      padx=4, pady=2, cursor="hand2").pack(side="left", padx=2)
+            _mk_chip(r, lbl,
+                     lambda w=w,h=h: (self._v_video_width.set(str(w)),
+                                      self._v_video_height.set(str(h)))
+                     ).pack(side="left", padx=2)
 
         # FPS
         r2 = tk.Frame(tab, bg=BG_DARK); r2.pack(fill="x", padx=12, pady=4)
@@ -2694,13 +2666,11 @@ class SettingsDialog(tk.Toplevel):
         tk.Entry(r2, textvariable=self._v_video_fps, width=5, bg=BG_CARD,
                  fg=TEXT_PRI, insertbackground=ACCENT, relief="flat", font=FM).pack(side="left")
         for fps in [30, 60, 120]:
-            tk.Button(r2, text=str(fps),
-                      command=lambda f=fps: self._v_video_fps.set(str(f)),
-                      bg=BG_CARD, fg=TEXT_DIM, font=FL, relief="flat",
-                      padx=4, pady=2, cursor="hand2").pack(side="left", padx=2)
-        tk.Button(r2, text="Detect", command=self._detect_camera_caps,
-                  bg=BG_CARD, fg=ACCENT, font=FL, relief="flat",
-                  padx=6, pady=2, cursor="hand2").pack(side="left", padx=(8, 0))
+            _mk_chip(r2, str(fps),
+                     lambda f=fps: self._v_video_fps.set(str(f))
+                     ).pack(side="left", padx=2)
+        _mk_chip(r2, "Detect", self._detect_camera_caps).pack(
+            side="left", padx=(8, 0))
         self._cam_caps_lbl = tk.Label(r2, text="", bg=BG_DARK, fg=TEXT_DIM, font=FL)
         self._cam_caps_lbl.pack(side="left", padx=4)
 
@@ -2797,10 +2767,9 @@ class SettingsDialog(tk.Toplevel):
                  fg=TEXT_PRI, insertbackground=ACCENT, relief="flat",
                  font=FM).pack(side="left")
         for lbl, val in [("2",2.0),("4",4.0),("6",6.0),("8",8.0),("12",12.0)]:
-            tk.Button(r_cc, text=lbl,
-                      command=lambda v=val: self._v_clahe_clip.set(str(v)),
-                      bg=BG_CARD, fg=TEXT_DIM, font=FL, relief="flat",
-                      padx=4, pady=2, cursor="hand2").pack(side="left", padx=2)
+            _mk_chip(r_cc, lbl,
+                     lambda v=val: self._v_clahe_clip.set(str(v))
+                     ).pack(side="left", padx=2)
         tk.Label(r_cc, text="  2=mild  4=balanced  8=aggressive  12=extreme",
                  bg=BG_DARK, fg=TEXT_DIM, font=FL).pack(side="left", padx=4)
 
@@ -2814,10 +2783,9 @@ class SettingsDialog(tk.Toplevel):
                  bg=BG_CARD, fg=TEXT_PRI, insertbackground=ACCENT,
                  relief="flat", font=FM).pack(side="left")
         for lbl, val in [("64",64),("96",96),("128",128),("160",160),("192",192)]:
-            tk.Button(r_bt, text=lbl,
-                      command=lambda v=val: self._v_brightness_target.set(str(v)),
-                      bg=BG_CARD, fg=TEXT_DIM, font=FL, relief="flat",
-                      padx=4, pady=2, cursor="hand2").pack(side="left", padx=2)
+            _mk_chip(r_bt, lbl,
+                     lambda v=val: self._v_brightness_target.set(str(v))
+                     ).pack(side="left", padx=2)
         tk.Label(r_bt, text="  lower=darker/faster  128=balanced  higher=brighter",
                  bg=BG_DARK, fg=TEXT_DIM, font=FL).pack(side="left", padx=4)
 
@@ -2835,10 +2803,9 @@ class SettingsDialog(tk.Toplevel):
                  bg=BG_CARD, fg=TEXT_PRI, insertbackground=ACCENT,
                  relief="flat", font=FM).pack(side="left")
         for lbl, val in [("15",15),("20",20),("25",25),("35",35),("50",50)]:
-            tk.Button(r_sv, text=lbl,
-                      command=lambda v=val: self._v_spike_velocity_mm.set(str(v)),
-                      bg=BG_CARD, fg=TEXT_DIM, font=FL, relief="flat",
-                      padx=4, pady=2, cursor="hand2").pack(side="left", padx=2)
+            _mk_chip(r_sv, lbl,
+                     lambda v=val: self._v_spike_velocity_mm.set(str(v))
+                     ).pack(side="left", padx=2)
         tk.Label(r_sv, text="  lower=more sensitive  25=default  higher=less sensitive",
                  bg=BG_DARK, fg=TEXT_DIM, font=FL).pack(side="left", padx=4)
 
@@ -2851,10 +2818,9 @@ class SettingsDialog(tk.Toplevel):
                  bg=BG_CARD, fg=TEXT_PRI, insertbackground=ACCENT,
                  relief="flat", font=FM).pack(side="left")
         for lbl, val in [("0.5",0.5),("0.6",0.6),("0.7",0.7),("0.8",0.8),("0.9",0.9)]:
-            tk.Button(r_sr, text=lbl,
-                      command=lambda v=val: self._v_spike_reversal.set(str(v)),
-                      bg=BG_CARD, fg=TEXT_DIM, font=FL, relief="flat",
-                      padx=4, pady=2, cursor="hand2").pack(side="left", padx=2)
+            _mk_chip(r_sr, lbl,
+                     lambda v=val: self._v_spike_reversal.set(str(v))
+                     ).pack(side="left", padx=2)
         tk.Label(r_sr, text="  0.5=loose  0.7=default  0.9=strict",
                  bg=BG_DARK, fg=TEXT_DIM, font=FL).pack(side="left", padx=4)
 
@@ -2894,11 +2860,9 @@ class SettingsDialog(tk.Toplevel):
                                      font=FM)
         self._zero_x_lbl.pack(side="left")
         self._update_zero_display()
-        tk.Button(r_zo, text="Reset to (0, 0)",
-                  command=self._reset_zero_offset,
-                  bg=ACCENT2, fg=BG_DARK, font=FL, relief="flat",
-                  padx=8, pady=3, cursor="hand2"
-                  ).pack(side="right")
+        _reset_zero_btn = _mk_btn(r_zo, "Reset to (0, 0)",
+                                  self._reset_zero_offset, danger=True)
+        _reset_zero_btn.pack(side="right")
 
         tk.Label(tab, text="Shot Handling", bg=BG_DARK, fg=ACCENT,
                  font=FT).pack(anchor="nw", padx=12, pady=(10, 4))
@@ -2915,10 +2879,9 @@ class SettingsDialog(tk.Toplevel):
                              insertbackground=ACCENT, relief="flat", font=FM)
         cal_entry.pack(side="left")
         for label, val in [("4.5",4.5),("5.6",5.6)]:
-            tk.Button(r_cal, text=label,
-                      command=lambda v=val: self._v_scoring_calibre.set(str(v)),
-                      bg=BG_CARD, fg=TEXT_DIM, font=FL, relief="flat",
-                      padx=4, pady=2, cursor="hand2").pack(side="left", padx=2)
+            _mk_chip(r_cal, label,
+                     lambda v=val: self._v_scoring_calibre.set(str(v))
+                     ).pack(side="left", padx=2)
         tk.Label(r_cal, text="  affects scoring bands & approach zone",
                  bg=BG_DARK, fg=TEXT_DIM, font=FL).pack(side="left", padx=4)
 
@@ -2952,15 +2915,11 @@ class SettingsDialog(tk.Toplevel):
         setattr(self, "_v_save_directory", v)
         tk.Entry(r, textvariable=v, width=22, bg=BG_CARD, fg=TEXT_PRI,
                  insertbackground=ACCENT, relief="flat", font=FM).pack(side="left", padx=(0,4))
-        tk.Button(r, text="Browse…", command=self._browse_save_dir,
-                  bg=BG_CARD, fg=TEXT_SEC, font=FL, relief="flat",
-                  padx=6, pady=3, cursor="hand2").pack(side="left")
+        _mk_chip(r, "Browse…", self._browse_save_dir).pack(side="left")
         def _use_default():
             v.set("")
             self._status_lbl.config(text="Reset to default location")
-        tk.Button(r, text="↺ Default", command=_use_default,
-                  bg=BG_CARD, fg=TEXT_DIM, font=FL, relief="flat",
-                  padx=6, pady=3, cursor="hand2").pack(side="left", padx=2)
+        _mk_chip(r, "↺ Default", _use_default).pack(side="left", padx=2)
         tk.Frame(tab, bg=BG_DARK, height=16).pack()
     def _build_colours(self, tab):
         self._note(tab, "Click a swatch to pick a colour. Changes apply on Apply.")
@@ -2991,10 +2950,9 @@ class SettingsDialog(tk.Toplevel):
                  font=FB, width=24, anchor="w").pack(side="left")
         self._v_trace_width = tk.StringVar(value=str(self.cfg.get("trace_width", 1)))
         for w in [1, 2, 3, 4]:
-            tk.Button(r, text=str(w),
-                      command=lambda v=w: self._v_trace_width.set(str(v)),
-                      bg=BG_CARD, fg=TEXT_DIM, font=FB, relief="flat",
-                      padx=8, pady=3, cursor="hand2").pack(side="left", padx=2)
+            _mk_chip(r, str(w),
+                     lambda v=w: self._v_trace_width.set(str(v))
+                     ).pack(side="left", padx=2)
         tk.Entry(r, textvariable=self._v_trace_width, width=3,
                  bg=BG_CARD, fg=TEXT_PRI, insertbackground=ACCENT,
                  relief="flat", font=FM).pack(side="left", padx=4)
@@ -3008,10 +2966,9 @@ class SettingsDialog(tk.Toplevel):
                  bg=BG_CARD, fg=TEXT_PRI, insertbackground=ACCENT,
                  relief="flat", font=FM).pack(side="left")
         for s in [1, 2, 4, 8]:
-            tk.Button(r2, text=str(s),
-                      command=lambda v=s: self._v_fading_trace_duration_s.set(str(v)),
-                      bg=BG_CARD, fg=TEXT_DIM, font=FL, relief="flat",
-                      padx=4, pady=2, cursor="hand2").pack(side="left", padx=2)
+            _mk_chip(r2, str(s),
+                     lambda v=s: self._v_fading_trace_duration_s.set(str(v))
+                     ).pack(side="left", padx=2)
         tk.Frame(tab, bg=BG_DARK, height=16).pack()
 
     def _colour_row(self, parent, label: str, key: str):
@@ -3046,9 +3003,7 @@ class SettingsDialog(tk.Toplevel):
                                title=f"Choose colour — {label}")
             if result and result[1]:
                 v.set(result[1].upper())
-        tk.Button(r, text="Pick…", command=_pick,
-                  bg=BG_CARD, fg=TEXT_SEC, font=FL, relief="flat",
-                  padx=6, pady=2, cursor="hand2").pack(side="left", padx=(4, 0))
+        _mk_chip(r, "Pick…", _pick).pack(side="left", padx=(4, 0))
     def _build_advanced(self, tab):
         self._section(tab, "Shooter Profile")
         self._row(tab, "Shooter name",
@@ -3280,9 +3235,8 @@ class SeriesReviewWindow(tk.Toplevel):
         self._series_combo.pack(side="left", pady=10)
         self._series_combo.bind("<<ComboboxSelected>>", self._on_series_selected)
 
-        tk.Button(top, text="⟳", command=self._populate_series_picker,
-                  bg=BG_MID, fg=TEXT_SEC, font=FL, relief="flat",
-                  cursor="hand2", padx=6).pack(side="left", padx=4)
+        _mk_btn(top, "⟳", self._populate_series_picker).pack(
+            side="left", padx=4)
 
         self._view_lbl = tk.Label(top, text="", bg=BG_MID, fg=TEXT_DIM, font=FL)
         self._view_lbl.pack(side="right", padx=12)
@@ -3364,14 +3318,10 @@ class SeriesReviewWindow(tk.Toplevel):
         hdr.pack(fill="x", padx=6, pady=(4, 2))
         tk.Label(hdr, text="SHOTS  (✓=show, ✕=delete)",
                  bg=BG_CARD, fg=TEXT_DIM, font=FL).pack(side="left")
-        tk.Button(hdr, text="All",
-                  command=lambda: self._select_all(True),
-                  bg=BG_CARD, fg=TEXT_DIM, font=FL,
-                  relief="flat", padx=4, cursor="hand2").pack(side="right")
-        tk.Button(hdr, text="None",
-                  command=lambda: self._select_all(False),
-                  bg=BG_CARD, fg=TEXT_DIM, font=FL,
-                  relief="flat", padx=4, cursor="hand2").pack(side="right")
+        _mk_chip(hdr, "All",
+                 lambda: self._select_all(True)).pack(side="right")
+        _mk_chip(hdr, "None",
+                 lambda: self._select_all(False)).pack(side="right")
 
         # Scrollable shot rows
         sf2 = tk.Frame(lc, bg=BG_DARK)
@@ -3400,32 +3350,18 @@ class SeriesReviewWindow(tk.Toplevel):
         self._list_canvas.bind("<MouseWheel>", _wheel)
         bf = tk.Frame(parent, bg=BG_PANEL)
         bf.pack(fill="x", padx=6, pady=(0, 6))
-        tk.Button(bf, text="▶  Next Series",
-                  command=self._next_series,
-                  bg=ACCENT, fg=BG_DARK, font=FB, relief="flat",
-                  pady=6, cursor="hand2").pack(fill="x", pady=1)
-        tk.Button(bf, text="💾  Save CSV",
-                  command=self._save,
-                  bg=BG_CARD, fg=TEXT_SEC, font=FB, relief="flat",
-                  pady=5, cursor="hand2").pack(fill="x", pady=1)
-        tk.Button(bf, text="✕  Close",
-                  command=self._on_close,
-                  bg=BG_CARD, fg=TEXT_SEC, font=FB, relief="flat",
-                  pady=5, cursor="hand2").pack(fill="x", pady=1)
+        _mk_btn(bf, "▶  Next Series", self._next_series,
+                accent=True).pack(fill="x", pady=1)
+        _mk_btn(bf, "💾  Save CSV", self._save).pack(fill="x", pady=1)
+        _mk_btn(bf, "✕  Close", self._on_close).pack(fill="x", pady=1)
 
     def _make_tog_btn(self, parent, text, var, col):
         """Create a toggle button that actually works — no closure bug."""
         def toggle():
             var.set(not var.get())
-            btn.config(
-                bg=col    if var.get() else BG_CARD,
-                fg=BG_DARK if var.get() else TEXT_SEC)
+            _set_toggle(btn, var.get(), accent_color=col)
             self._redraw()
-        btn = tk.Button(parent, text=text, command=toggle,
-                        bg=col    if var.get() else BG_CARD,
-                        fg=BG_DARK if var.get() else TEXT_SEC,
-                        font=FL, relief="flat", bd=0,
-                        padx=6, pady=4, cursor="hand2")
+        btn = _mk_toggle(parent, text, var.get(), toggle, accent_color=col)
         return btn
     def _populate_series_picker(self):
         """Build the day + series dropdowns from live session and saved files."""
@@ -3583,11 +3519,9 @@ class SeriesReviewWindow(tk.Toplevel):
 
             # Delete button — only for live editable sessions
             if self._is_live:
-                tk.Button(row, text="✕",
-                          command=lambda s=shot: self._delete_shot(s),
-                          bg=BG_DARK, fg=ACCENT2,
-                          font=("Consolas", 9), relief="flat", bd=0,
-                          padx=3, cursor="hand2").pack(side="right")
+                _mk_chip(row, "✕",
+                         lambda s=shot: self._delete_shot(s)
+                         ).pack(side="right")
 
     def _on_shot_toggle(self, shot, var):
         shot.deleted = not var.get()

--- a/ui/app.py
+++ b/ui/app.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import math
 import os
 import queue
-import sys
 import threading
 import time
 import tkinter as tk
@@ -3599,7 +3598,6 @@ class SeriesReviewWindow(tk.Toplevel):
                 v.config(text="—", fg=TEXT_SEC)
             return
 
-        import numpy as np
         coords = np.array([s.aim_mm for s in visible])
         radii  = np.sqrt(coords[:,0]**2 + coords[:,1]**2)
         score  = sum(s.score for s in visible)

--- a/ui/app.py
+++ b/ui/app.py
@@ -22,10 +22,14 @@ import numpy as np
 from PIL import Image, ImageTk
 
 from core.audio import AudioDetector
-from core.config import TARGETS, VERSION, load_config, save_config
-from core.marker_sheet import generate_marker_sheet
-from core.session import (Session, Shot, ShotTrace,
-                          load_session_history, reconstruct_shot_traces)
+from core.config import (TARGETS, VERSION, _load_target_csv, _targets_dir,
+                          _user_targets_dir, load_all_targets, load_config,
+                          save_config)
+from core.marker_sheet import (A4_W_MM, AIMING_MARKS, _get_aiming_marks,
+                                generate_marker_sheet)
+from core.session import (APPROACH_ZONE_FACTOR, Session, Shot, ShotTrace,
+                          TracePoint, load_session_history,
+                          reconstruct_shot_traces)
 from core.smoother import make_smoother
 from core.target_renderer import TargetRenderer
 from core.tracker import ArucoTracker, score_shot
@@ -1413,7 +1417,6 @@ class SplattApp:
             self.cfg.get("fading_trace_duration_s", 2.0))
         self.session.acp_fraction = float(
             self.cfg.get("acp_fraction", 0.40))
-        from core.session import APPROACH_ZONE_FACTOR
         factor = float(self.cfg.get("approach_zone_factor",
                                      APPROACH_ZONE_FACTOR))
         R = self._scoring_radius_mm()
@@ -1753,7 +1756,6 @@ class SplattApp:
 
     def _show_first_run_wizard(self):
         """Simple first-run setup wizard shown when no config file exists."""
-        from core.config import TARGETS, save_config
         dlg = tk.Toplevel(self.root)
         dlg.title("Welcome to Splatt2!")
         dlg.configure(bg=BG_DARK)
@@ -1843,7 +1845,6 @@ class MarkerSheetDialog(tk.Toplevel):
         self.geometry("500x520")
 
     def _build(self):
-        from core.marker_sheet import AIMING_MARKS, A4_W_MM
         nb = ttk.Notebook(self)
         nb.pack(fill="both", expand=True, padx=8, pady=8)
 
@@ -1858,7 +1859,6 @@ class MarkerSheetDialog(tk.Toplevel):
         pad = {"padx": 14, "pady": 5}  # keep for legacy refs
 
     def _build_sheet_tab(self, parent):
-        from core.marker_sheet import AIMING_MARKS, A4_W_MM
         pad = {"padx": 14, "pady": 5}
 
         tk.Label(parent, text="Generate Marker Sheet", bg=BG_DARK, fg=ACCENT,
@@ -1963,7 +1963,6 @@ class MarkerSheetDialog(tk.Toplevel):
         self._preview()
 
     def _get(self):
-        from core.marker_sheet import AIMING_MARKS
         key  = self._tvar.get()
         mark = AIMING_MARKS.get(key, AIMING_MARKS["10m_air_rifle"])
         try:    dist = float(self._dvar.get())
@@ -1975,7 +1974,6 @@ class MarkerSheetDialog(tk.Toplevel):
         return key, mark, dist, dist / mark["reference_dist_m"], marker_sz, margin_sz
 
     def _preview(self, *_):
-        from core.marker_sheet import A4_W_MM
         key, mark, dist, scale, marker_sz, margin_sz = self._get()
         # Centre space = A4 width - 2 margins - 2 markers (left+right)
         centre_space = A4_W_MM - 2 * margin_sz - 2 * marker_sz
@@ -2000,12 +1998,10 @@ class MarkerSheetDialog(tk.Toplevel):
             initialfile=f"splatt2_{key}_{dist:.0f}m.png")
         if not out:
             return
-        from core.marker_sheet import generate_marker_sheet
         _, _, _, _, marker_sz, margin_sz = self._get()
         # Save marker/margin back to cfg so tracker stays in sync
         self.cfg["aruco_marker_mm"] = marker_sz
         self.cfg["aruco_margin_mm"] = margin_sz
-        from core.config import save_config
         save_config(self.cfg)
         generate_marker_sheet(out, target_key=key, print_distance_m=dist,
                                show_ring_guides=self._rvar.get(),
@@ -2020,7 +2016,6 @@ class MarkerSheetDialog(tk.Toplevel):
         self.destroy()
     def _build_creator_tab(self, parent):
         """Target editor — create, edit and delete targets from the targets/ folder."""
-        from core.config import TARGETS, _targets_dir
         pad = {"padx": 10, "pady": 3}
         top = tk.Frame(parent, bg=BG_DARK); top.pack(fill="x", **pad)
         tk.Label(top, text="Mode:", bg=BG_DARK, fg=TEXT_SEC,
@@ -2149,7 +2144,6 @@ class MarkerSheetDialog(tk.Toplevel):
 
     def _on_creator_mode(self, event=None):
         """Load an existing target into the editor fields."""
-        from core.config import TARGETS
         mode = self._c_mode.get()
         if mode == "New target":
             self._c_key.set(""); self._c_name.set("")
@@ -2184,7 +2178,6 @@ class MarkerSheetDialog(tk.Toplevel):
 
     def _delete_target(self):
         """Delete a user-created target CSV. Built-in targets can't be removed."""
-        from core.config import TARGETS, _user_targets_dir
         mode = self._c_mode.get()
         if mode == "New target":
             self._c_status.config(text="Select an existing target to delete.", fg=GOLD)
@@ -2208,7 +2201,6 @@ class MarkerSheetDialog(tk.Toplevel):
             import core.config as _cc, core.marker_sheet as _ms
             # Reload — a built-in seed with the same key may now resurface.
             _cc.TARGETS = _cc._load_all_targets()
-            from core.marker_sheet import _get_aiming_marks
             _ms.AIMING_MARKS = _get_aiming_marks()
             self._c_status.config(text=f"Deleted '{t['name']}'.", fg=ACCENT)
             modes = ["New target"] + [f"Edit: {tgt['name']}" for tgt in _cc.TARGETS.values()]
@@ -2219,7 +2211,6 @@ class MarkerSheetDialog(tk.Toplevel):
 
     def _save_target(self):
         """Validate and save the target as a CSV in the user targets dir."""
-        from core.config import _user_targets_dir, _load_target_csv
         import core.config as _cc, core.marker_sheet as _ms
 
         key  = self._c_key.get().strip().replace(" ","_")
@@ -2292,7 +2283,6 @@ class MarkerSheetDialog(tk.Toplevel):
         t = _load_target_csv(path)
         if t:
             _cc.TARGETS[t["key"]] = t
-            from core.marker_sheet import _get_aiming_marks
             _ms.AIMING_MARKS = _get_aiming_marks()
             # Refresh mode dropdown
             modes = ["New target"] + [f"Edit: {tgt['name']}" for tgt in _cc.TARGETS.values()]
@@ -2363,7 +2353,6 @@ class SessionHistoryWindow(tk.Toplevel):
         self.after(200, self._init_renderer)
 
     def _init_renderer(self):
-        from core.target_renderer import TargetRenderer
         w = self._tgt.winfo_width()
         h = self._tgt.winfo_height()
         if w < 50 or h < 50:
@@ -2374,7 +2363,6 @@ class SessionHistoryWindow(tk.Toplevel):
         self._redraw()
 
     def _load(self):
-        from core.session import load_session_history
         # _history is {day_label: [entry, ...]} newest day first
         self._history_dict = load_session_history(self.save_dir)
         # Flatten to a list for display, newest first
@@ -2409,7 +2397,6 @@ class SessionHistoryWindow(tk.Toplevel):
             pass
 
     def _show(self, idx):
-        from core.session import reconstruct_shot_traces
         e = self._history[idx]
         self._sel = e
         dur = e["duration_s"]
@@ -2439,7 +2426,6 @@ class SessionHistoryWindow(tk.Toplevel):
     def _redraw(self):
         if self._renderer is None:
             return
-        from core.session import Shot, ShotTrace, TracePoint, reconstruct_shot_traces
         shots = []
         if self._sel:
             traces = reconstruct_shot_traces(self._sel["raw"])
@@ -3332,7 +3318,6 @@ class SeriesReviewWindow(tk.Toplevel):
         return btn
     def _populate_series_picker(self):
         """Build the day + series dropdowns from live session and saved files."""
-        from core.session import load_session_history
         save_dir = (self.cfg.get("save_directory") or "").strip() or _default_save_dir()
         save_dir = os.path.abspath(save_dir)
 
@@ -3422,7 +3407,6 @@ class SeriesReviewWindow(tk.Toplevel):
             self._view_lbl.config(text="● LIVE" if self._is_live else "○ Past",
                                    fg=ACCENT if self._is_live else TEXT_DIM)
         else:
-            from core.session import Session, Shot, reconstruct_shot_traces
             raw_shots = entry["raw_shots"]
             traces    = reconstruct_shot_traces({"shots": raw_shots})
             fake_sess = Session(entry["history"]["name"])
@@ -3521,7 +3505,6 @@ class SeriesReviewWindow(tk.Toplevel):
         self._update_stats()
         self._redraw()
     def _init_renderer(self):
-        from core.target_renderer import TargetRenderer
         w = self._canvas.winfo_width()
         h = self._canvas.winfo_height()
         if w < 50 or h < 50:
@@ -3535,7 +3518,6 @@ class SeriesReviewWindow(tk.Toplevel):
         self._populate_series_picker()
 
     def _on_canvas_resize(self, event):
-        from core.target_renderer import TargetRenderer
         if event.width < 50 or event.height < 50:
             return
         cal = float(self.cfg.get("shot_circle_calibre_mm",

--- a/ui/app.py
+++ b/ui/app.py
@@ -241,19 +241,11 @@ class SplattApp:
                                      bg=BG_MID, fg=TEXT_SEC, font=FH)
         self._session_lbl.pack(side="left", padx=8)
         self._status_lbl = tk.Label(top, text="● READY", bg=BG_MID,
-                                    fg=TEXT_SEC, font=("Consolas", 9),
-                                    width=60, anchor="e")
+                                    fg=TEXT_SEC, font=("Consolas", 9))
         self._status_lbl.pack(side="right", padx=16)
         self._tracking_lbl = tk.Label(top, text="TRACKING: —", bg=BG_MID,
-                                      fg=TEXT_DIM, font=("Consolas", 9),
-                                      width=14, anchor="e")
+                                      fg=TEXT_DIM, font=("Consolas", 9))
         self._tracking_lbl.pack(side="right", padx=8)
-        _mk_btn(top, "📋  Series", self._open_series_tab).pack(
-            side="right", padx=4, pady=8)
-        _mk_btn(top, "🖨  Target Sheet", self._print_markers).pack(
-            side="right", padx=4, pady=8)
-        _mk_btn(top, "💾  Save CSV", self._save_csv).pack(
-            side="right", padx=4, pady=8)
 
         # Body
         body = tk.Frame(self.root, bg=BG_DARK)
@@ -454,9 +446,28 @@ class SplattApp:
             id(self._btn_group): GOLD,
         }
 
-        # Shot log
-        lc = tk.Frame(parent, bg=BG_CARD)
+        # Action buttons must be packed before the shot log so the
+        # ``side="bottom"`` slice is reserved first; otherwise the
+        # ``expand=True`` shot log claims all remaining space and the
+        # buttons are pushed below the visible area.
+        bf = tk.Frame(parent, bg=BG_PANEL)
+        bf.pack(side="bottom", fill="x", padx=6, pady=(0, 4))
+        _mk_btn(bf, "⟲  Undo Shot",    self._undo_shot).pack(fill="x", pady=1)
+        self._btn_start_series = _mk_btn(bf, "▶  Start Series",
+                                              self._start_series, accent=True)
+        self._btn_start_series.pack(fill="x", pady=1)
+        _mk_btn(bf, "📋  Series Review", self._open_series_tab).pack(fill="x", pady=1)
+        _mk_btn(bf, "◻  Reset All",    self._reset_all).pack(fill="x", pady=1)
+        tk.Frame(bf, bg=BG_PANEL, height=3).pack()
+        _mk_btn(bf, "⊞  Marker Sheet", self._print_markers).pack(fill="x", pady=1)
+        _mk_btn(bf, "💾  Save CSV",     self._save_csv).pack(fill="x", pady=1)
+
+        # Shot log. Sized to a fixed minimum height so it stays visible
+        # even when the right column is short; the inner Text widget
+        # then expands into any remaining vertical space.
+        lc = tk.Frame(parent, bg=BG_CARD, height=180)
         lc.pack(fill="both", expand=True, padx=6, pady=(0, 3))
+        lc.pack_propagate(False)
         hdr = tk.Frame(lc, bg=BG_CARD)
         hdr.pack(fill="x", padx=8, pady=(6, 2))
         tk.Label(hdr, text="SHOT LOG", bg=BG_CARD, fg=TEXT_DIM, font=FL).pack(side="left")
@@ -479,19 +490,6 @@ class SplattApp:
                          ("hdr", TEXT_DIM),("sel", ACCENT)]:
             self._shot_log.tag_config(tag, foreground=col)
         self._shot_log.tag_config("sel_bg", background=BG_CARD)
-
-        # Action buttons
-        bf = tk.Frame(parent, bg=BG_PANEL)
-        bf.pack(fill="x", padx=6, pady=(0, 4))
-        _mk_btn(bf, "⟲  Undo Shot",    self._undo_shot).pack(fill="x", pady=1)
-        self._btn_start_series = _mk_btn(bf, "▶  Start Series",
-                                              self._start_series, accent=True)
-        self._btn_start_series.pack(fill="x", pady=1)
-        _mk_btn(bf, "📋  Series Review", self._open_series_tab).pack(fill="x", pady=1)
-        _mk_btn(bf, "◻  Reset All",    self._reset_all).pack(fill="x", pady=1)
-        tk.Frame(bf, bg=BG_PANEL, height=3).pack()
-        _mk_btn(bf, "⊞  Marker Sheet", self._print_markers).pack(fill="x", pady=1)
-        _mk_btn(bf, "💾  Save CSV",     self._save_csv).pack(fill="x", pady=1)
     def _build_bottom_bar(self, parent):
         _mk_btn(parent, "❙❙  Pause", self._toggle_pause).pack(
             side="left", padx=(8, 3), pady=5)

--- a/ui/app.py
+++ b/ui/app.py
@@ -207,6 +207,10 @@ class SplattApp:
         self._tracking_lbl.pack(side="right", padx=8)
         _mk_btn(top, "📋  Series", self._open_series_tab).pack(
             side="right", padx=4, pady=8)
+        _mk_btn(top, "🖨  Target Sheet", self._print_markers).pack(
+            side="right", padx=4, pady=8)
+        _mk_btn(top, "💾  Save CSV", self._save_csv).pack(
+            side="right", padx=4, pady=8)
 
         # Body
         body = tk.Frame(self.root, bg=BG_DARK)
@@ -1911,7 +1915,24 @@ class SplattApp:
 
         tk.Button(dlg, text="Let's go  ▶", command=_done,
                   bg=ACCENT, fg=BG_DARK, font=("Segoe UI", 11, "bold"),
-                  relief="flat", padx=20, pady=8, cursor="hand2").pack(pady=20)
+                  relief="flat", padx=20, pady=8, cursor="hand2").pack(pady=(20, 4))
+
+        def _print_now():
+            # Persist current wizard choices so the sheet uses the right
+            # target/distance, then open the marker sheet dialog over the
+            # wizard. The user can return here when they're done.
+            try:
+                self.cfg["real_range_m"] = float(dist_var.get())
+            except ValueError:
+                pass
+            self.cfg["target_key"] = target_var.get()
+            self.target_cfg = TARGETS[self.cfg["target_key"]]
+            MarkerSheetDialog(dlg, self.cfg)
+
+        tk.Button(dlg, text="🖨  Print marker sheet now",
+                  command=_print_now,
+                  bg=BG_CARD, fg=TEXT_PRI, font=("Segoe UI", 9),
+                  relief="flat", padx=12, pady=4, cursor="hand2").pack(pady=(0, 16))
 
         # Prevent closing without completing
         dlg.protocol("WM_DELETE_WINDOW", _done)

--- a/ui/app.py
+++ b/ui/app.py
@@ -2260,8 +2260,8 @@ class MarkerSheetDialog(tk.Toplevel):
         self._update_creator_preview()
 
     def _delete_target(self):
-        """Delete the selected existing target CSV."""
-        from core.config import TARGETS, _targets_dir
+        """Delete a user-created target CSV. Built-in targets can't be removed."""
+        from core.config import TARGETS, _user_targets_dir
         mode = self._c_mode.get()
         if mode == "New target":
             self._c_status.config(text="Select an existing target to delete.", fg=GOLD)
@@ -2270,29 +2270,33 @@ class MarkerSheetDialog(tk.Toplevel):
         t   = next((t for t in TARGETS.values() if t["name"] == key), None)
         if t is None:
             return
+        path = os.path.join(_user_targets_dir(), f"{t['key']}.csv")
+        if not os.path.isfile(path):
+            self._c_status.config(
+                text=f"'{t['name']}' is a built-in target and can't be deleted.",
+                fg=GOLD)
+            return
         if not messagebox.askyesno("Delete Target",
                 f"Permanently delete '{t['name']}' ({t['key']}.csv)?\n"
                 "This cannot be undone."):
             return
-        import os as _os
-        path = _os.path.join(_targets_dir(), f"{t['key']}.csv")
         try:
-            _os.remove(path)
+            os.remove(path)
             import core.config as _cc, core.marker_sheet as _ms
-            _cc.TARGETS.pop(t["key"], None)
+            # Reload — a built-in seed with the same key may now resurface.
+            _cc.TARGETS = _cc._load_all_targets()
             from core.marker_sheet import _get_aiming_marks
             _ms.AIMING_MARKS = _get_aiming_marks()
             self._c_status.config(text=f"Deleted '{t['name']}'.", fg=ACCENT)
-            # Refresh mode dropdown
             modes = ["New target"] + [f"Edit: {tgt['name']}" for tgt in _cc.TARGETS.values()]
             self._c_mode_combo["values"] = modes
             self._c_mode.set("New target")
-        except Exception as e:
+        except OSError as e:
             self._c_status.config(text=f"Delete failed: {e}", fg=ACCENT2)
 
     def _save_target(self):
-        """Validate and save the target as a CSV in the targets/ folder."""
-        from core.config import _targets_dir, _load_target_csv
+        """Validate and save the target as a CSV in the user targets dir."""
+        from core.config import _user_targets_dir, _load_target_csv
         import core.config as _cc, core.marker_sheet as _ms
 
         key  = self._c_key.get().strip().replace(" ","_")
@@ -2332,7 +2336,7 @@ class MarkerSheetDialog(tk.Toplevel):
             card_d = diameters[-1]
 
         # Check if overwriting a file
-        tdir  = _targets_dir()
+        tdir  = _user_targets_dir()
         os.makedirs(tdir, exist_ok=True)
         fname = f"{key}.csv"
         path  = os.path.join(tdir, fname)

--- a/ui/app.py
+++ b/ui/app.py
@@ -1090,34 +1090,57 @@ class SplattApp:
                 text=f"#{last.index} {sc_str}pts ({last.aim_mm[0]:+.1f},{last.aim_mm[1]:+.1f}){acp_s}{ot_s}",
                 fg=GOLD if sc >= 9 else (ACCENT if sc >= 7 else TEXT_SEC))
 
+    @staticmethod
+    def _shot_flags(shot: Shot) -> str:
+        """Compact flag string for the shot log."""
+        flags = ""
+        if not shot.match_shot:
+            flags += "S"
+        if shot.favourite:
+            flags += "★"
+        if shot.missed:
+            flags += "M"
+        if shot.comments:
+            flags += "✎"
+        return flags
+
+    @staticmethod
+    def _shot_log_tag(score: float) -> str:
+        """Colour tag for a shot in the shot log."""
+        if score >= 10:
+            return "ten"
+        if score >= 9:
+            return "nine"
+        if score >= 7:
+            return "mid"
+        if score > 0:
+            return "low"
+        return "miss"
+
     def _refresh_shot_log(self):
         log = self._shot_log
         log.config(state="normal")
         log.delete("1.0", "end")
-        log.insert("end", f"{'#':>3}  {'Sc':>5}  {'X':>6}  {'Y':>6}  {'T':>4}  Flg\n", "hdr")
+        log.insert("end",
+                   f"{'#':>3}  {'Sc':>5}  {'X':>6}  {'Y':>6}  {'T':>4}  Flg\n",
+                   "hdr")
         log.insert("end", "─" * 38 + "\n", "hdr")
-        shots_rev = list(reversed(self.session.shots[-40:]))
-        for shot in shots_rev:
+
+        for shot in reversed(self.session.shots[-40:]):
             if shot.deleted:
-                continue   # don't show deleted shots in log
-            sc   = shot.score
-            sc_s = f"{sc:.1f}" if sc != int(sc) else str(int(sc))
-            ot   = f"{shot.on_target_duration_s:.1f}"
-            # Build flag string
-            flags = ""
-            if not shot.match_shot: flags += "S"   # S = Sighter
-            if shot.favourite:      flags += "★"
-            if shot.missed:         flags += "M"
-            if shot.comments:       flags += "✎"
-            line = (f"{shot.index:>3}  {sc_s:>5}  "
-                    f"{shot.aim_mm[0]:>+6.1f}  {shot.aim_mm[1]:>+6.1f}  "
-                    f"{ot:>4}  {flags}\n")
-            tag  = ("ten"  if sc >= 10 else "nine" if sc >= 9 else
-                    "mid"  if sc >= 7  else "low"  if sc > 0  else "miss")
+                continue
+            score = shot.score
+            score_str = (f"{score:.1f}" if score != int(score)
+                         else str(int(score)))
+            line = (
+                f"{shot.index:>3}  {score_str:>5}  "
+                f"{shot.aim_mm[0]:>+6.1f}  {shot.aim_mm[1]:>+6.1f}  "
+                f"{shot.on_target_duration_s:>4.1f}  {self._shot_flags(shot)}\n"
+            )
             if self._selected_shot and self._selected_shot.index == shot.index:
                 log.insert("end", line, ("sel", "sel_bg"))
             else:
-                log.insert("end", line, tag)
+                log.insert("end", line, self._shot_log_tag(score))
         log.config(state="disabled")
 
     def _update_audio_meter(self):

--- a/ui/app.py
+++ b/ui/app.py
@@ -770,33 +770,32 @@ class SplattApp:
     def _register_shot(self, aim_mm, shot_ts: float = None):
         if not self._series_started:
             return
-        R            = self._scoring_radius_mm()
-        mark_offsets = self.target_cfg.get("mark_offsets")  # None for single-mark
+        R = self._scoring_radius_mm()
+        mark_offsets = self.target_cfg.get("mark_offsets")
 
-        # Step 1: record the shot — this does the retroactive position lookup,
-        # correcting aim_mm to where the crosshair actually was at shot_ts.
-        # We pass a placeholder score of 0.0 and rescore after using the
-        # corrected position, so scoring and drawing use identical coordinates.
-        shot = self.session.record_shot(aim_mm, 0.0, 0,
-                                         shot_timestamp=shot_ts,
-                                         mark_index=0,
-                                         defer_write=True)
+        # Record first with a placeholder score so we can rescore using the
+        # retroactively corrected aim, ensuring scoring and rendering use
+        # the same coordinates.
+        shot = self.session.record_shot(
+            aim_mm, 0.0, 0,
+            shot_timestamp=shot_ts,
+            mark_index=0,
+            defer_write=True,
+        )
         if shot is None:
             self.root.after(0, lambda: self._set_status(
                 "SHOT REJECTED — outside approach zone", ACCENT2))
             return
 
-        # Step 2: score from the retroactively corrected position
-        score, ring, mark_idx = score_shot(shot.aim_mm, R,
-                                            decimal=self._decimal_scoring,
-                                            mark_offsets=mark_offsets)
-
-        # Step 3: update the shot with the correct score and mark
-        shot.score      = score
+        score, ring, mark_idx = score_shot(
+            shot.aim_mm, R,
+            decimal=self._decimal_scoring,
+            mark_offsets=mark_offsets,
+        )
+        shot.score = score
         shot.ring_index = ring
         shot.mark_index = mark_idx
 
-        # Step 4: rewrite the live CSV row with the correct score
         if self.session._writer and self.session._writer.is_open:
             self.session._writer.write_shot(shot)
 
@@ -805,20 +804,16 @@ class SplattApp:
             self.root.after(0, lambda: self._set_status(
                 "Miss ignored (score 0)", TEXT_DIM))
             return
-        if shot is None:
-            self.root.after(0, lambda: self._set_status(
-                "SHOT REJECTED — outside approach zone", ACCENT2))
-            return
-        import time as _t
-        self._last_shot_fired_time = _t.time()
+
+        self._last_shot_fired_time = time.time()
         self._last_shot_info = shot
-        sc = shot.score
-        sc_s = f"{sc:.1f}" if sc != int(sc) else str(int(sc))
-        col = GOLD if sc >= 10 else (ACCENT if sc >= 9 else
-              TEXT_PRI if sc >= 7 else ACCENT2)
-        _lbl = (f"Shot #{shot.index} (mark {mark_idx+1}): {sc_s} pts"
-                if mark_offsets else f"Shot #{shot.index}: {sc_s} pts")
-        self.root.after(0, lambda lbl=_lbl, c=col: self._set_status(lbl, c))
+        sc_s = f"{score:.1f}" if score != int(score) else str(int(score))
+        col = (GOLD if score >= 10 else
+               ACCENT if score >= 9 else
+               TEXT_PRI if score >= 7 else ACCENT2)
+        label = (f"Shot #{shot.index} (mark {mark_idx + 1}): {sc_s} pts"
+                 if mark_offsets else f"Shot #{shot.index}: {sc_s} pts")
+        self.root.after(0, lambda lbl=label, c=col: self._set_status(lbl, c))
 
 
     def _open_camera_properties(self):

--- a/ui/app.py
+++ b/ui/app.py
@@ -50,6 +50,33 @@ def _default_save_dir() -> str:
         return os.path.join(os.path.expanduser("~"), "Documents", "Splatt2")
 
 
+_ROTATION_FLAGS = {
+    90: cv2.ROTATE_90_CLOCKWISE,
+    180: cv2.ROTATE_180,
+    270: cv2.ROTATE_90_COUNTERCLOCKWISE,
+}
+
+
+class _FpsCounter:
+    """Rolling FPS counter that updates twice per second."""
+
+    def __init__(self, window_s: float = 0.5):
+        self._window = window_s
+        self._frames = 0
+        self._last = time.time()
+        self.value = 0.0
+
+    def tick(self) -> float:
+        self._frames += 1
+        now = time.time()
+        elapsed = now - self._last
+        if elapsed >= self._window:
+            self.value = self._frames / elapsed
+            self._frames = 0
+            self._last = now
+        return self.value
+
+
 def _compute_scoring_radius_mm(target_cfg: dict, cfg: dict) -> float:
     """Single source of truth for the scoring radius (R = card_r + pellet_r)."""
     card_r = target_cfg["diameter_mm"] / 2.0
@@ -616,16 +643,11 @@ class SplattApp:
         - UI preview is only updated every N frames to save tkinter overhead
         - 'no_video_mode': skip annotated frame entirely, pure tracking only
         """
-        no_video   = self.cfg.get("no_video_mode", False)
-        ui_every   = 3        # send frame to UI every 3rd detection
+        no_video = self.cfg.get("no_video_mode", False)
+        ui_every = 3
         ui_counter = 0
-        detect_w   = 640      # ArUco detection width (never larger than capture)
-        detect_h   = 480
-
-        # Live FPS measurement
-        _fps_frame_count = 0
-        _fps_last_time   = time.time()
-        _fps_display     = 0.0
+        detect_w, detect_h = 640, 480
+        fps = _FpsCounter()
 
         while self._running:
             if not self._cap or not self._cap.isOpened():
@@ -635,107 +657,109 @@ class SplattApp:
                 time.sleep(0.005)
                 continue
 
-
             if self.cfg.get("flip_image"):
                 frame = cv2.flip(frame, self.cfg.get("flip_mode", -1))
+            rotation = _ROTATION_FLAGS.get(self._camera_rotation)
+            if rotation is not None:
+                frame = cv2.rotate(frame, rotation)
 
-            # Camera rotation (0 / 90 / 180 / 270 degrees)
-            rot = self._camera_rotation
-            if rot == 90:
-                frame = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
-            elif rot == 180:
-                frame = cv2.rotate(frame, cv2.ROTATE_180)
-            elif rot == 270:
-                frame = cv2.rotate(frame, cv2.ROTATE_90_COUNTERCLOCKWISE)
-
-            # Downscale for detection — major speed improvement
-            fh, fw = frame.shape[:2]
-            if fw > detect_w or fh > detect_h:
-                scale = min(detect_w / fw, detect_h / fh)
-                small = cv2.resize(frame,
-                                   (int(fw * scale), int(fh * scale)),
-                                   interpolation=cv2.INTER_LINEAR)
-            else:
-                small = frame
-
-            # Laplacian variance — only computed when focus assist is on
+            small = self._downscale_for_detection(frame, detect_w, detect_h)
             if self._focus_active:
-                _lap = cv2.Laplacian(small if len(small.shape)==2
-                                     else cv2.cvtColor(small, cv2.COLOR_BGR2GRAY),
-                                     cv2.CV_64F)
-                self._sharpness = float(_lap.var())
+                self._sharpness = self._measure_sharpness(small)
 
             result = self.tracker.process_frame(small)
             self._tracking_quality = result.quality
             self._current_markers_found = result.markers_found
 
             if result.aim_mm is not None and not self._paused:
-                raw = result.aim_mm
-                zeroed = (raw[0] - self._zero_offset[0],
-                          raw[1] - self._zero_offset[1])
-                if result.quality >= 0.25:
-                    filtered = self._reject_spike(zeroed)
-                    self._raw_aim_prev2 = self._raw_aim_prev
-                    self._raw_aim_prev = zeroed
-                    smoothed = self._smoother.update(filtered)
-                    self._current_aim_mm = smoothed
-                    in_appr, on_tgt = self.session.update_aim(smoothed)
-                    self._in_approach_zone = in_appr
-                    self._on_target_status = on_tgt
+                self._consume_aim(result)
 
-            # Measure actual delivered FPS
-            _fps_frame_count += 1
-            _fps_now = time.time()
-            _fps_elapsed = _fps_now - _fps_last_time
-            if _fps_elapsed >= 0.5:   # update every half second
-                _fps_display     = _fps_frame_count / _fps_elapsed
-                _fps_frame_count = 0
-                _fps_last_time   = _fps_now
-            self._live_fps = _fps_display
-            # Update sharpness peak hold (only when focus assist is on)
+            self._live_fps = fps.tick()
             if self._focus_active:
-                _now = time.time()
-                if self._sharpness >= self._sharpness_peak:
-                    self._sharpness_peak   = self._sharpness
-                    self._sharpness_peak_t = _now
-                elif _now - self._sharpness_peak_t > 3.0:
-                    self._sharpness_peak = self._sharpness
+                self._update_sharpness_peak()
 
-            # Only update UI preview every N frames and not in no_video mode
             ui_counter += 1
             if not no_video and ui_counter >= ui_every:
-                # Overlay FPS on the camera frame
-                disp = result.frame_display.copy() if result.frame_display is not None else None
-                if disp is not None:
-                    fps_txt = f"{_fps_display:.1f} fps"
-                    cv2.putText(disp, fps_txt, (6, 16),
-                                cv2.FONT_HERSHEY_SIMPLEX, 0.45,
-                                (80, 220, 80), 1, cv2.LINE_AA)
-                    self._latest_cam_frame = disp
+                self._publish_camera_frame(result.frame_display, self._live_fps)
                 ui_counter = 0
 
-            try:
-                shot_ts = self._shot_queue.get_nowait()
-                if self._current_aim_mm is not None:
-                    if self._zero_mode:
-                        if self._tracking_quality > 0:
-                            # Markers visible — apply zero
-                            self._apply_zero(self._current_aim_mm)
-                        else:
-                            # No markers — ignore trigger, stay in zero mode
-                            self.root.after(0, lambda: self._set_status(
-                                "ZERO MODE — no markers, try again", GOLD))
-                    elif self._tracking_quality > 0:
-                        # quality > 0 means we have a valid homography
-                        # Pass shot_ts so record_shot can retroactively look up
-                        # the camera position at the exact audio trigger moment
-                        self._register_shot(self._current_aim_mm, shot_ts)
-                    else:
-                        # quality == 0: no homography at all, camera lost
-                        self.root.after(0, lambda: self._set_status(
-                            "SHOT REJECTED — no tracking", ACCENT2))
-            except queue.Empty:
-                pass
+            self._drain_shot_queue()
+
+    def _downscale_for_detection(self, frame, max_w: int, max_h: int):
+        """Resize ``frame`` so it fits within (max_w, max_h) for detection."""
+        fh, fw = frame.shape[:2]
+        if fw <= max_w and fh <= max_h:
+            return frame
+        scale = min(max_w / fw, max_h / fh)
+        return cv2.resize(
+            frame, (int(fw * scale), int(fh * scale)),
+            interpolation=cv2.INTER_LINEAR,
+        )
+
+    @staticmethod
+    def _measure_sharpness(frame) -> float:
+        """Laplacian variance — proxy for focus quality."""
+        gray = (frame if len(frame.shape) == 2
+                else cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY))
+        return float(cv2.Laplacian(gray, cv2.CV_64F).var())
+
+    def _update_sharpness_peak(self) -> None:
+        now = time.time()
+        if self._sharpness >= self._sharpness_peak:
+            self._sharpness_peak = self._sharpness
+            self._sharpness_peak_t = now
+        elif now - self._sharpness_peak_t > 3.0:
+            self._sharpness_peak = self._sharpness
+
+    def _consume_aim(self, result) -> None:
+        """Apply zero, spike-filter, smooth and feed the session aim."""
+        raw = result.aim_mm
+        zeroed = (raw[0] - self._zero_offset[0],
+                  raw[1] - self._zero_offset[1])
+        if result.quality < 0.25:
+            return
+        filtered = self._reject_spike(zeroed)
+        self._raw_aim_prev2 = self._raw_aim_prev
+        self._raw_aim_prev = zeroed
+        smoothed = self._smoother.update(filtered)
+        self._current_aim_mm = smoothed
+        in_appr, on_tgt = self.session.update_aim(smoothed)
+        self._in_approach_zone = in_appr
+        self._on_target_status = on_tgt
+
+    def _publish_camera_frame(self, frame_display, live_fps: float) -> None:
+        """Annotate the latest detection frame and hand it to the UI thread."""
+        if frame_display is None:
+            return
+        disp = frame_display.copy()
+        cv2.putText(disp, f"{live_fps:.1f} fps", (6, 16),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.45,
+                    (80, 220, 80), 1, cv2.LINE_AA)
+        self._latest_cam_frame = disp
+
+    def _drain_shot_queue(self) -> None:
+        """Process any queued audio triggers against the current aim."""
+        try:
+            shot_ts = self._shot_queue.get_nowait()
+        except queue.Empty:
+            return
+
+        if self._current_aim_mm is None:
+            return
+
+        if self._zero_mode:
+            if self._tracking_quality > 0:
+                self._apply_zero(self._current_aim_mm)
+            else:
+                self.root.after(0, lambda: self._set_status(
+                    "ZERO MODE — no markers, try again", GOLD))
+            return
+
+        if self._tracking_quality > 0:
+            self._register_shot(self._current_aim_mm, shot_ts)
+        else:
+            self.root.after(0, lambda: self._set_status(
+                "SHOT REJECTED — no tracking", ACCENT2))
 
     def _reject_spike(self, zeroed: tuple) -> tuple:
         """Return ``zeroed`` unless it is a bad homography spike.

--- a/ui/app.py
+++ b/ui/app.py
@@ -45,20 +45,25 @@ def _default_save_dir() -> str:
         return os.path.join(os.path.expanduser("~"), "Documents", "Splatt2")
 
 
+def _compute_scoring_radius_mm(target_cfg: dict, cfg: dict) -> float:
+    """Single source of truth for the scoring radius (R = card_r + pellet_r)."""
+    card_r = target_cfg["diameter_mm"] / 2.0
+    calibre = float(cfg.get("scoring_calibre_mm",
+                            target_cfg.get("calibre_mm", 4.5)))
+    return card_r + calibre / 2.0
+
+
 class SplattApp:
     def __init__(self):
         self.cfg, self._first_run = load_config()
         self.target_cfg = TARGETS[self.cfg["target_key"]]
-        _card_r   = self.target_cfg["diameter_mm"] / 2.0
-        _calibre  = float(self.cfg.get("scoring_calibre_mm",
-                          self.target_cfg.get("calibre_mm", 4.5)))
-        _R        = _card_r + _calibre / 2.0
         self.session = Session(
             name=self.cfg["session_name"],
             shots_per_series=self.cfg["shots_per_series"],
-            scoring_radius_mm=_R,
+            scoring_radius_mm=_compute_scoring_radius_mm(
+                self.target_cfg, self.cfg),
         )
-        self._apply_session_cfg()  # wire cfg into session at startup
+        self._apply_session_cfg()
         self.tracker = ArucoTracker(
             aruco_dict_name=self.cfg.get("aruco_dict", "DICT_4X4_50"),
             marker_size_mm=float(self.cfg.get("aruco_marker_mm", 40.0)),
@@ -70,25 +75,26 @@ class SplattApp:
         )
         self.target_renderer = None
 
+        # ~12 ms chunks keep latency low while still capturing the click.
         self.audio = AudioDetector(
             threshold=self.cfg.get("audio_trigger_threshold", 0.15),
             transient_ratio=self.cfg.get("audio_transient_ratio", 6.0),
             cooldown_ms=self.cfg.get("audio_trigger_cooldown_ms", 800),
             sample_rate=self.cfg.get("audio_sample_rate", 44100),
-            chunk_size=512,          # ~12ms chunks — low latency, still enough for transient detection
+            chunk_size=512,
             device_index=self.cfg.get("audio_device_index"),
             on_shot=self._on_shot_detected,
         )
 
-        # State
+        # Camera and tracking state.
         self._cap = None
         self._running = False
         self._paused = False
         self._shot_queue = queue.Queue()
-        self._current_aim_mm  = None
-        self._raw_aim_prev     = None   # previous raw position (pre-smoother)
-        self._raw_aim_prev2    = None   # two frames ago (for velocity reversal)
-        self._spike_hold       = None   # buffered position during spike candidate
+        self._current_aim_mm = None
+        self._raw_aim_prev = None
+        self._raw_aim_prev2 = None
+        self._spike_hold = None
         self._tracking_quality = 0.0
         self._zero_offset = (
             float(self.cfg.get("zero_offset_x", 0.0)),
@@ -96,53 +102,55 @@ class SplattApp:
         )
         self._zero_mode = False
         self._decimal_scoring = self.cfg.get("decimal_scoring", False)
-        self._zoom_factor      = 1.0   # target canvas zoom (0.3–1.5)
-        self._live_fps         = 0.0   # measured camera FPS
-        self._sharpness        = 0.0   # Laplacian variance (focus measure)
-        self._sharpness_peak   = 0.0   # peak hold
-        self._sharpness_peak_t = 0.0   # time of peak
+        self._zoom_factor = 1.0
+        self._live_fps = 0.0
+        self._sharpness = 0.0
+        self._sharpness_peak = 0.0
+        self._sharpness_peak_t = 0.0
+
+        # Display toggles.
         self._show_acp = True
         self._show_bbox_shots = False
         self._show_bbox_acp = False
-        self._show_group = False    # show group circle (blue) and MPI cross
+        self._show_group = False
+        self._shot_dot_only = False
         self._highlighted_trace: ShotTrace = None
         self._on_target_status = False
         self._in_approach_zone = False
+
+        # Series and shot state.
         self._series_started = False
-        self._post_shot_cooldown_s = float(self.cfg.get("post_shot_cooldown_s", 2.0))
+        self._post_shot_cooldown_s = float(
+            self.cfg.get("post_shot_cooldown_s", 2.0))
         self._last_shot_fired_time: float = 0.0
         self._last_shot_info = None
-        self._current_markers_found: int = 0   # updated every camera frame
+        self._current_markers_found: int = 0
         self._camera_rotation = int(self.cfg.get("camera_rotation", 0))
-        self._fine_zero_mode = False   # click-on-canvas zero fine-tune
-        self._shot_dot_only = False       # True=dot, False=full circle
+        self._fine_zero_mode = False
         self._smoother = make_smoother(
             self.cfg.get("smooth_mode", "ema"),
             alpha=self.cfg.get("smooth_alpha", 0.35),
             window=self.cfg.get("smooth_window", 11),
             poly=self.cfg.get("smooth_poly", 2),
         )
-        self._selected_shot: Shot = None   # for shot log selection
+        self._selected_shot: Shot = None
         self._latest_cam_frame = None
 
-        # Series editor state
+        # Series editor state. ``BooleanVar``s need a root, so they're
+        # bound after ``_build_window`` runs.
         self._in_series_editor = False
-        self._editor_shot_vars = {}      # shot.index -> BooleanVar
-        # BooleanVars must be created AFTER the root window exists
+        self._editor_shot_vars = {}
         self._editor_show_trace = None
-        self._editor_show_acp   = None
-        self._editor_show_dur   = None
+        self._editor_show_acp = None
+        self._editor_show_dur = None
 
-        self._build_window()   # creates self.root
-        # Start update loop — runs always, not just when camera active
+        self._build_window()
         self.root.after(100, self._update_loop)
-        # First-run wizard — shown after window is ready
         if self._first_run:
             self.root.after(300, self._show_first_run_wizard)
-        # Now safe to create tk variables
         self._editor_show_trace = tk.BooleanVar(value=True)
-        self._editor_show_acp   = tk.BooleanVar(value=True)
-        self._editor_show_dur   = tk.BooleanVar(value=True)
+        self._editor_show_acp = tk.BooleanVar(value=True)
+        self._editor_show_dur = tk.BooleanVar(value=True)
         self._apply_styles()
     def _build_window(self):
         self.root = tk.Tk()
@@ -757,15 +765,8 @@ class SplattApp:
         self._shot_queue.put(ts)
 
     def _scoring_radius_mm(self) -> float:
-        """
-        R = card_radius + pellet_radius.
-        This is the single number that drives all scoring geometry.
-        Changing calibre in settings instantly changes all scoring bands.
-        """
-        card_r    = self.target_cfg["diameter_mm"] / 2.0
-        calibre   = float(self.cfg.get("scoring_calibre_mm",
-                          self.target_cfg.get("calibre_mm", 4.5)))
-        return card_r + calibre / 2.0
+        """Scoring radius derived from the target card and pellet calibre."""
+        return _compute_scoring_radius_mm(self.target_cfg, self.cfg)
 
     def _register_shot(self, aim_mm, shot_ts: float = None):
         if not self._series_started:

--- a/ui/app.py
+++ b/ui/app.py
@@ -8,6 +8,7 @@ windows live alongside it: :class:`MarkerSheetDialog`,
 
 from __future__ import annotations
 
+import math
 import os
 import queue
 import sys
@@ -669,33 +670,9 @@ class SplattApp:
                 zeroed = (raw[0] - self._zero_offset[0],
                           raw[1] - self._zero_offset[1])
                 if result.quality >= 0.25:
-                    # Detects bad homography spikes: a large jump that immediately
-                    # reverses. Genuine fast movement (recoil, swing) continues
-                    # in the same direction — it does not sharply reverse.
-                    filtered = zeroed
-                    if self._raw_aim_prev is not None:
-                        import math as _m
-                        spk_vel  = float(self.cfg.get("spike_velocity_mm", 25.0))
-                        spk_rev  = float(self.cfg.get("spike_reversal", 0.7))
-                        px, py   = self._raw_aim_prev
-                        vx = zeroed[0] - px
-                        vy = zeroed[1] - py
-                        speed = _m.sqrt(vx*vx + vy*vy)
-                        if speed > spk_vel and self._raw_aim_prev2 is not None:
-                            # Check if previous frame also had a large jump
-                            # and this frame reverses it
-                            p2x, p2y = self._raw_aim_prev2
-                            v2x = px - p2x
-                            v2y = py - p2y
-                            dot = vx*v2x + vy*v2y
-                            mag2 = _m.sqrt(v2x*v2x + v2y*v2y)
-                            if mag2 > spk_vel and dot < -spk_rev * speed * mag2:
-                                # Sharp reversal detected — this frame is the
-                                # return from a spike. Discard both spike frames.
-                                filtered = self._raw_aim_prev2
-                                self._raw_aim_prev  = self._raw_aim_prev2
+                    filtered = self._reject_spike(zeroed)
                     self._raw_aim_prev2 = self._raw_aim_prev
-                    self._raw_aim_prev  = zeroed
+                    self._raw_aim_prev = zeroed
                     smoothed = self._smoother.update(filtered)
                     self._current_aim_mm = smoothed
                     in_appr, on_tgt = self.session.update_aim(smoothed)
@@ -755,6 +732,41 @@ class SplattApp:
                             "SHOT REJECTED — no tracking", ACCENT2))
             except queue.Empty:
                 pass
+
+    def _reject_spike(self, zeroed: tuple) -> tuple:
+        """Return ``zeroed`` unless it is a bad homography spike.
+
+        A spike is detected when the previous and current frames both
+        show large displacements but in nearly opposite directions:
+        genuine fast movement keeps direction; a marker dropout snaps
+        to a wrong position then back.
+        """
+        if self._raw_aim_prev is None or self._raw_aim_prev2 is None:
+            return zeroed
+
+        spike_velocity = float(self.cfg.get("spike_velocity_mm", 25.0))
+        reversal = float(self.cfg.get("spike_reversal", 0.7))
+
+        px, py = self._raw_aim_prev
+        vx = zeroed[0] - px
+        vy = zeroed[1] - py
+        speed = math.hypot(vx, vy)
+        if speed <= spike_velocity:
+            return zeroed
+
+        p2x, p2y = self._raw_aim_prev2
+        v2x = px - p2x
+        v2y = py - p2y
+        prev_speed = math.hypot(v2x, v2y)
+        if prev_speed <= spike_velocity:
+            return zeroed
+
+        dot = vx * v2x + vy * v2y
+        if dot < -reversal * speed * prev_speed:
+            # Discard the spike pair: roll the running history back one frame.
+            self._raw_aim_prev = self._raw_aim_prev2
+            return self._raw_aim_prev2
+        return zeroed
 
     def _on_shot_detected(self, ts):
         if self._paused:
@@ -1406,11 +1418,10 @@ class SplattApp:
                                      APPROACH_ZONE_FACTOR))
         R = self._scoring_radius_mm()
         self.session.scoring_radius_mm = R
-        # For multi-mark targets, the approach zone must cover the furthest mark
+        # For multi-mark targets, the approach zone must cover the furthest mark.
         mark_offsets = self.target_cfg.get("mark_offsets")
         if mark_offsets:
-            import math as _m
-            max_mark_r = max(_m.sqrt(mx**2 + my**2) for mx, my in mark_offsets)
+            max_mark_r = max(math.hypot(mx, my) for mx, my in mark_offsets)
             self.session.approach_radius_mm = (R + max_mark_r) * factor
         else:
             self.session.approach_radius_mm = R * factor

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,69 +1,43 @@
-"""
-ui/app.py — Splatt2 main window.
+"""Splatt2 Tkinter UI.
 
-Layout:
-  Top bar    : title, session name, Sessions history button, status
-  Left       : camera feed + camera selector + tracking quality
-  Centre     : target canvas
-  Right      : score panel OR series-complete editor (swappable)
-  Bottom     : pause / zero / decimal / mic sensitivity slider / on-target indicator
+The main window is :class:`SplattApp`. Modal dialogs and review
+windows live alongside it: :class:`MarkerSheetDialog`,
+:class:`SessionHistoryWindow`, :class:`SettingsDialog` and
+:class:`SeriesReviewWindow`.
 """
 
-import tkinter as tk
-from tkinter import ttk, messagebox, filedialog
+from __future__ import annotations
+
+import os
+import queue
+import sys
 import threading
 import time
-import queue
-import os
-import sys
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
 
 import cv2
 import numpy as np
 from PIL import Image, ImageTk
 
-from core.config import load_config, save_config, TARGETS, VERSION
-from core.tracker import ArucoTracker, score_shot
 from core.audio import AudioDetector
+from core.config import TARGETS, VERSION, load_config, save_config
+from core.marker_sheet import generate_marker_sheet
 from core.session import (Session, Shot, ShotTrace,
                           load_session_history, reconstruct_shot_traces)
-from core.target_renderer import TargetRenderer
-from core.marker_sheet import generate_marker_sheet
 from core.smoother import make_smoother
-
-# ── Palette ───────────────────────────────────────────────────────────────────
-BG_DARK  = "#0f0f13"
-BG_MID   = "#16161d"
-BG_PANEL = "#1c1c25"
-BG_CARD  = "#22222e"
-ACCENT   = "#00e5a0"
-ACCENT2  = "#ff4f6d"
-TEXT_PRI = "#f0f0f8"
-TEXT_SEC = "#c0c0d8"
-TEXT_DIM = "#9090b0"
-BORDER   = "#2a2a3a"
-GOLD     = "#ffd060"
-
-FM = ("Consolas", 10)
-FT = ("Segoe UI", 9, "bold")
-FS = ("Consolas", 42, "bold")
-FL = ("Segoe UI", 9)
-FB = ("Segoe UI", 10)
-FH = ("Segoe UI", 11)
-
-
-def _mk_btn(parent, text, cmd, accent=False, width=None):
-    fg = BG_DARK if accent else TEXT_SEC
-    bg = ACCENT if accent else BG_CARD
-    kw = dict(bg=bg, fg=fg, activebackground=ACCENT if accent else BORDER,
-              activeforeground=fg, font=FB, relief="flat", bd=0,
-              padx=8, pady=5, cursor="hand2", text=text, command=cmd)
-    if width:
-        kw["width"] = width
-    return tk.Button(parent, **kw)
+from core.target_renderer import TargetRenderer
+from core.tracker import ArucoTracker, score_shot
+from ui.theme import (
+    ACCENT, ACCENT2, BG_CARD, BG_DARK, BG_MID, BG_PANEL, BORDER, GOLD,
+    TEXT_DIM, TEXT_PRI, TEXT_SEC,
+    FB, FH, FL, FM, FS, FT,
+    make_button as _mk_btn,
+)
 
 
 def _default_save_dir() -> str:
-    """Per-user sessions/ folder. Falls back to ~/Documents/Splatt2 on error."""
+    """Per-user ``sessions/`` folder, with a documents fallback on error."""
     try:
         from core.paths import sessions_dir
         return str(sessions_dir())

--- a/ui/app.py
+++ b/ui/app.py
@@ -144,11 +144,6 @@ class SplattApp:
         self._editor_show_acp   = tk.BooleanVar(value=True)
         self._editor_show_dur   = tk.BooleanVar(value=True)
         self._apply_styles()
-
-    # =========================================================================
-    # WINDOW BUILD
-    # =========================================================================
-
     def _build_window(self):
         self.root = tk.Tk()
         self.root.title(f"SPLATT2 v{VERSION} — Target Shooting Trainer")
@@ -205,8 +200,6 @@ class SplattApp:
 
         self.root.protocol("WM_DELETE_WINDOW", self._on_close)
         self.root.bind("<KeyPress>", self._on_key)
-
-    # ── Camera panel ──────────────────────────────────────────────────────────
     def _build_camera_panel(self, parent):
         tk.Label(parent, text="CAMERA FEED", bg=BG_PANEL, fg=TEXT_DIM,
                  font=FL).pack(anchor="nw", padx=8, pady=(6, 0))
@@ -264,8 +257,6 @@ class SplattApp:
         self._btn_cam.pack(side="left")
         _mk_btn(cf, "⚙  Settings", self._open_settings).pack(side="right")
         _mk_btn(cf, "🎛  Cam Props", self._open_camera_properties).pack(side="right", padx=4)
-
-    # ── Target panel ──────────────────────────────────────────────────────────
     def _build_target_panel(self, parent):
         tk.Label(parent, text="TARGET", bg=BG_PANEL, fg=TEXT_DIM,
                  font=FL).pack(anchor="nw", padx=8, pady=(6, 0))
@@ -286,8 +277,6 @@ class SplattApp:
         self._aim_lbl = tk.Label(info, text="Aim: — mm",
                                  bg=BG_PANEL, fg=TEXT_DIM, font=FM)
         self._aim_lbl.pack(side="right")
-
-    # ── Score panel ───────────────────────────────────────────────────────────
     def _build_score_panel(self, parent):
         # Score card
         sc = tk.Frame(parent, bg=BG_CARD)
@@ -424,8 +413,6 @@ class SplattApp:
         tk.Frame(bf, bg=BG_PANEL, height=3).pack()
         _mk_btn(bf, "⊞  Marker Sheet", self._print_markers).pack(fill="x", pady=1)
         _mk_btn(bf, "💾  Save CSV",     self._save_csv).pack(fill="x", pady=1)
-
-    # ── Bottom bar ────────────────────────────────────────────────────────────
     def _build_bottom_bar(self, parent):
         _mk_btn(parent, "❙❙  Pause", self._toggle_pause).pack(
             side="left", padx=(8, 3), pady=5)
@@ -516,11 +503,6 @@ class SplattApp:
                     padding=[8, 3])
         s.map("TNotebook.Tab", background=[("selected", BG_PANEL)],
               foreground=[("selected", ACCENT)])
-
-    # =========================================================================
-    # CAMERA
-    # =========================================================================
-
     def _scan_cameras(self):
         self._cam_combo.config(state="disabled")
         self._cam_combo["values"] = ["Scanning..."]
@@ -679,7 +661,6 @@ class SplattApp:
                 zeroed = (raw[0] - self._zero_offset[0],
                           raw[1] - self._zero_offset[1])
                 if result.quality >= 0.25:
-                    # ── Velocity spike filter (raw positions, pre-smoother) ──
                     # Detects bad homography spikes: a large jump that immediately
                     # reverses. Genuine fast movement (recoil, swing) continues
                     # in the same direction — it does not sharply reverse.
@@ -868,11 +849,6 @@ class SplattApp:
             self._btn_zero.config(text="◎  Zero", bg=BG_CARD, fg=TEXT_SEC),
             self._set_status("ZEROED", ACCENT)
         ))
-
-    # =========================================================================
-    # UPDATE LOOP
-    # =========================================================================
-
     def _update_loop(self):
         # Target display and scores run always (even without camera)
         # so colour changes / shot edits reflect immediately
@@ -1082,11 +1058,6 @@ class SplattApp:
     def _update_audio_meter(self):
         level = min(1.0, self.audio.current_level * 12)
         self._audio_var.set(level * 100)
-
-    # =========================================================================
-    # CONTROLS
-    # =========================================================================
-
     def _on_exp_mode(self):
         """Auto exposure checkbox changed — apply live."""
         if hasattr(self, '_exp_auto_var'):
@@ -1478,8 +1449,6 @@ class SplattApp:
 
     def _set_status(self, text, color=TEXT_SEC):
         self._status_lbl.config(text=f"● {text}", fg=color)
-
-    # ── Shot log interactions ─────────────────────────────────────────────────
     def _shot_at_log_line(self, event):
         try:
             line_no = int(self._shot_log.index(
@@ -1595,11 +1564,6 @@ class SplattApp:
             if self._selected_shot and self._selected_shot.index == shot.index:
                 self._selected_shot = None
                 self._highlighted_trace = None
-
-    # =========================================================================
-    # SERIES COMPLETE EDITOR
-    # =========================================================================
-
     def _series_complete(self):
         """Finish shooting, save, enter review mode."""
         # End live file (also writes JSON)
@@ -1746,11 +1710,6 @@ class SplattApp:
     def _editor_select_all(self, value: bool):
         for var in self._editor_shot_vars.values():
             var.set(value)
-
-    # =========================================================================
-    # KEYBOARD
-    # =========================================================================
-
     def _on_key(self, event):
         k = event.keysym.lower()
         if k == "p":         self._toggle_pause()
@@ -1758,11 +1717,6 @@ class SplattApp:
         elif k == "r":       self._reset_all()
         elif k == "q":       self._on_close()
         elif k == "s":       self._save_csv()
-
-    # =========================================================================
-    # LIFECYCLE
-    # =========================================================================
-
     def _on_close(self):
         self._running = False
         self.audio.stop()
@@ -1863,11 +1817,6 @@ class SplattApp:
 
     def run(self):
         self.root.mainloop()
-
-
-# =============================================================================
-# SETTINGS DIALOG
-# =============================================================================
 
 class MarkerSheetDialog(tk.Toplevel):
     def __init__(self, parent, cfg):
@@ -2056,15 +2005,10 @@ class MarkerSheetDialog(tk.Toplevel):
         except Exception:
             pass
         self.destroy()
-
-    # ── Target Creator tab ────────────────────────────────────────────────────
-
     def _build_creator_tab(self, parent):
         """Target editor — create, edit and delete targets from the targets/ folder."""
         from core.config import TARGETS, _targets_dir
         pad = {"padx": 10, "pady": 3}
-
-        # ── Mode selector: New or edit existing ──────────────────────────────
         top = tk.Frame(parent, bg=BG_DARK); top.pack(fill="x", **pad)
         tk.Label(top, text="Mode:", bg=BG_DARK, fg=TEXT_SEC,
                  font=FB, width=8, anchor="w").pack(side="left")
@@ -2078,8 +2022,6 @@ class MarkerSheetDialog(tk.Toplevel):
         tk.Button(top, text="Delete", command=self._delete_target,
                   bg=ACCENT2, fg=BG_DARK, font=FL, relief="flat",
                   padx=6, pady=3, cursor="hand2").pack(side="left")
-
-        # ── Metadata fields ───────────────────────────────────────────────────
         meta = tk.Frame(parent, bg=BG_DARK); meta.pack(fill="x", **pad)
 
         def _field(frame, label, var, width=20):
@@ -2137,8 +2079,6 @@ class MarkerSheetDialog(tk.Toplevel):
         # Trace changes to update live preview
         for v in (self._c_calibre, self._c_card):
             v.trace_add("write", lambda *_: self._update_creator_preview())
-
-        # ── Ring data text area ───────────────────────────────────────────────
         tk.Label(parent,
                  text="Visual rings — score, ring_diameter_mm (innermost first):",
                  bg=BG_DARK, fg=TEXT_DIM, font=FL).pack(anchor="nw", padx=10, pady=(4,1))
@@ -2152,14 +2092,10 @@ class MarkerSheetDialog(tk.Toplevel):
             "10, 0.5\n9, 5.5\n8, 10.5\n7, 15.5\n6, 20.5\n"
             "5, 25.5\n4, 30.5\n3, 35.5\n2, 40.5\n1, 45.5")
         self._c_rings_txt.bind("<KeyRelease>", lambda *_: self._update_creator_preview())
-
-        # ── Live scoring preview ──────────────────────────────────────────────
         self._c_preview = tk.Label(parent, text="", bg=BG_CARD, fg=ACCENT,
                                     font=("Consolas", 9), justify="left",
                                     anchor="nw", padx=8, pady=4)
         self._c_preview.pack(fill="x", padx=10, pady=(0,2))
-
-        # ── Status + buttons ─────────────────────────────────────────────────
         self._c_status = tk.Label(parent, text="", bg=BG_DARK, fg=ACCENT,
                                    font=FM, anchor="w")
         self._c_status.pack(fill="x", padx=10)
@@ -2352,11 +2288,6 @@ class MarkerSheetDialog(tk.Toplevel):
         self._c_status.config(
             text=f"Saved '{name}' → {fname}  (available immediately)",
             fg=ACCENT)
-
-# =============================================================================
-# SESSION HISTORY WINDOW
-# =============================================================================
-
 class SessionHistoryWindow(tk.Toplevel):
     def __init__(self, parent, save_dir, cfg):
         super().__init__(parent)
@@ -2520,16 +2451,6 @@ class SessionHistoryWindow(tk.Toplevel):
         self._tgt._img = photo
 
 
-# =============================================================================
-# SERIES REVIEW WINDOW
-# =============================================================================
-
-
-
-# =============================================================================
-# SETTINGS DIALOG  (scrollable tabs, resizable)
-# =============================================================================
-
 class SettingsDialog(tk.Toplevel):
     """Scrollable settings dialog — each tab has a canvas+scrollbar so nothing
     is ever clipped regardless of screen size or font scaling."""
@@ -2545,9 +2466,6 @@ class SettingsDialog(tk.Toplevel):
         self.geometry("560x680")
         self.minsize(480, 500)
         self._build()
-
-    # ── shell ─────────────────────────────────────────────────────────────────
-
     def _build(self):
         # Fixed button row at BOTTOM (always visible)
         btn_row = tk.Frame(self, bg=BG_DARK)
@@ -2606,9 +2524,6 @@ class SettingsDialog(tk.Toplevel):
             builder(inner)
             # Force scroll region now that content is populated
             self.after(50, _refresh)
-
-    # ── helpers ───────────────────────────────────────────────────────────────
-
     def _row(self, parent, label, widget_fn):
         r = tk.Frame(parent, bg=BG_DARK)
         r.pack(fill="x", padx=12, pady=4)
@@ -2638,9 +2553,6 @@ class SettingsDialog(tk.Toplevel):
         setattr(self, f"_v_{key}", v)
         return ttk.Combobox(parent, textvariable=v, values=values,
                              width=18, state="readonly", font=FM)
-
-    # ── Camera tab ────────────────────────────────────────────────────────────
-
     def _build_cam(self, tab):
         self._section(tab, "Camera")
         self._row(tab, "Camera index", lambda p: self._entry(p, "camera_index", 4))
@@ -2837,9 +2749,6 @@ class SettingsDialog(tk.Toplevel):
                  bg=BG_DARK, fg=TEXT_DIM, font=FL).pack(side="left", padx=4)
 
         tk.Frame(tab, bg=BG_DARK, height=16).pack()   # bottom padding
-
-    # ── Audio tab ─────────────────────────────────────────────────────────────
-
     def _build_audio(self, tab):
         self._section(tab, "Shot Detection")
         self._note(tab, "Threshold: absolute peak floor (0.01–1.0)\n"
@@ -2860,9 +2769,6 @@ class SettingsDialog(tk.Toplevel):
                  ).pack(anchor="nw", padx=16)
         self._row(tab, "Device index (blank=auto)", lambda p: self._entry(p, "audio_device_index", 4))
         tk.Frame(tab, bg=BG_DARK, height=16).pack()
-
-    # ── Target tab ────────────────────────────────────────────────────────────
-
     def _build_target(self, tab):
         self._section(tab, "Target & Range")
         self._row(tab, "Target type",
@@ -2946,11 +2852,6 @@ class SettingsDialog(tk.Toplevel):
                   bg=BG_CARD, fg=TEXT_DIM, font=FL, relief="flat",
                   padx=6, pady=3, cursor="hand2").pack(side="left", padx=2)
         tk.Frame(tab, bg=BG_DARK, height=16).pack()
-
-    # ── Collect / Apply ───────────────────────────────────────────────────────
-
-    # ── Colours & Display tab ────────────────────────────────────────────────
-
     def _build_colours(self, tab):
         self._note(tab, "Click a swatch to pick a colour. Changes apply on Apply.")
 
@@ -3038,9 +2939,6 @@ class SettingsDialog(tk.Toplevel):
         tk.Button(r, text="Pick…", command=_pick,
                   bg=BG_CARD, fg=TEXT_SEC, font=FL, relief="flat",
                   padx=6, pady=2, cursor="hand2").pack(side="left", padx=(4, 0))
-
-    # ── Advanced tab ──────────────────────────────────────────────────────────
-
     def _build_advanced(self, tab):
         self._section(tab, "Shooter Profile")
         self._row(tab, "Shooter name",
@@ -3208,11 +3106,6 @@ class SettingsDialog(tk.Toplevel):
         else:
             self._cam_caps_lbl.config(text="No modes found")
 
-
-# =============================================================================
-# SERIES REVIEW WINDOW  (series picker, working toggles, scrollable shot list)
-# =============================================================================
-
 class SeriesReviewWindow(tk.Toplevel):
     """
     Review window with:
@@ -3257,13 +3150,7 @@ class SeriesReviewWindow(tk.Toplevel):
         self._build()
         self.protocol("WM_DELETE_WINDOW", self._on_close)
         self.after(150, self._init_renderer)
-
-    # =========================================================================
-    # BUILD
-    # =========================================================================
-
     def _build(self):
-        # ── Top bar: two-dropdown day / series picker ───────────────────────
         top = tk.Frame(self, bg=BG_MID)
         top.pack(side="top", fill="x")
 
@@ -3289,8 +3176,6 @@ class SeriesReviewWindow(tk.Toplevel):
 
         self._view_lbl = tk.Label(top, text="", bg=BG_MID, fg=TEXT_DIM, font=FL)
         self._view_lbl.pack(side="right", padx=12)
-
-        # ── Body ─────────────────────────────────────────────────────────────
         body = tk.Frame(self, bg=BG_DARK)
         body.pack(fill="both", expand=True)
 
@@ -3309,7 +3194,6 @@ class SeriesReviewWindow(tk.Toplevel):
         self._build_right(right)
 
     def _build_right(self, parent):
-        # ── Stats ─────────────────────────────────────────────────────────────
         sc = tk.Frame(parent, bg=BG_CARD)
         sc.pack(fill="x", padx=6, pady=(6, 3))
         tk.Label(sc, text="STATISTICS", bg=BG_CARD, fg=TEXT_DIM,
@@ -3336,8 +3220,6 @@ class SeriesReviewWindow(tk.Toplevel):
                              font=FM, anchor="w")
                 v.pack(side="left", padx=(2,8))
                 self._stat_lbls[key] = v
-
-        # ── Display toggles ────────────────────────────────────────────────────
         tc = tk.Frame(parent, bg=BG_PANEL)
         tc.pack(fill="x", padx=6, pady=(0, 4))
         tk.Label(tc, text="DISPLAY", bg=BG_PANEL, fg=TEXT_DIM,
@@ -3364,8 +3246,6 @@ class SeriesReviewWindow(tk.Toplevel):
             btn = self._make_tog_btn(r2, text, var, col)
             btn.pack(side="left", padx=(0, 2))
             self._tog_buttons[key] = btn
-
-        # ── Shot list ──────────────────────────────────────────────────────────
         lc = tk.Frame(parent, bg=BG_CARD)
         lc.pack(fill="both", expand=True, padx=6, pady=(0, 3))
 
@@ -3408,8 +3288,6 @@ class SeriesReviewWindow(tk.Toplevel):
         def _wheel(e):
             self._list_canvas.yview_scroll(int(-1*(e.delta/120)), "units")
         self._list_canvas.bind("<MouseWheel>", _wheel)
-
-        # ── Actions ────────────────────────────────────────────────────────────
         bf = tk.Frame(parent, bg=BG_PANEL)
         bf.pack(fill="x", padx=6, pady=(0, 6))
         tk.Button(bf, text="▶  Next Series",
@@ -3439,11 +3317,6 @@ class SeriesReviewWindow(tk.Toplevel):
                         font=FL, relief="flat", bd=0,
                         padx=6, pady=4, cursor="hand2")
         return btn
-
-    # =========================================================================
-    # SERIES PICKER
-    # =========================================================================
-
     def _populate_series_picker(self):
         """Build the day + series dropdowns from live session and saved files."""
         from core.session import load_session_history
@@ -3561,11 +3434,6 @@ class SeriesReviewWindow(tk.Toplevel):
         self._rebuild_shot_list()
         self._update_stats()
         self._redraw()
-
-    # =========================================================================
-    # SHOT LIST
-    # =========================================================================
-
     def _rebuild_shot_list(self):
         """Rebuild the per-shot checkbox rows for the current view."""
         for w in self._list_inner.winfo_children():
@@ -3639,11 +3507,6 @@ class SeriesReviewWindow(tk.Toplevel):
                 self._shot_chk_vars[shot.index].set(value)
         self._update_stats()
         self._redraw()
-
-    # =========================================================================
-    # RENDERER
-    # =========================================================================
-
     def _init_renderer(self):
         from core.target_renderer import TargetRenderer
         w = self._canvas.winfo_width()
@@ -3699,11 +3562,6 @@ class SeriesReviewWindow(tk.Toplevel):
         else:
             self._canvas.itemconfig(self._tgt_img_id, image=photo)
         self._canvas._img = photo
-
-    # =========================================================================
-    # STATS
-    # =========================================================================
-
     def _update_stats(self):
         visible = [s for s in self._view_session.shots
                    if s.series == self._view_series
@@ -3756,11 +3614,6 @@ class SeriesReviewWindow(tk.Toplevel):
             text=f"#{best.index} {best.score:.1f}", fg=GOLD)
         self._stat_lbls["worst"].config(
             text=f"#{worst.index} {worst.score:.1f}", fg=ACCENT2)
-
-    # =========================================================================
-    # ACTIONS
-    # =========================================================================
-
     def _next_series(self):
         if self.on_next_series:
             self.on_next_series()

--- a/ui/app.py
+++ b/ui/app.py
@@ -1963,14 +1963,18 @@ class MarkerSheetDialog(tk.Toplevel):
         self._preview()
 
     def _get(self):
-        key  = self._tvar.get()
+        key = self._tvar.get()
         mark = AIMING_MARKS.get(key, AIMING_MARKS["10m_air_rifle"])
-        try:    dist = float(self._dvar.get())
-        except: dist = mark["reference_dist_m"]
-        try:    marker_sz = max(10.0, float(self._mvar.get()))
-        except: marker_sz = 40.0
-        try:    margin_sz = max(3.0,  float(self._mgvar.get()))
-        except: margin_sz = 8.0
+
+        def _to_float(var, default):
+            try:
+                return float(var.get())
+            except (TypeError, ValueError):
+                return default
+
+        dist = _to_float(self._dvar, mark["reference_dist_m"])
+        marker_sz = max(10.0, _to_float(self._mvar, 40.0))
+        margin_sz = max(3.0, _to_float(self._mgvar, 8.0))
         return key, mark, dist, dist / mark["reference_dist_m"], marker_sz, margin_sz
 
     def _preview(self, *_):

--- a/ui/app.py
+++ b/ui/app.py
@@ -63,10 +63,10 @@ def _mk_btn(parent, text, cmd, accent=False, width=None):
 
 
 def _default_save_dir() -> str:
-    """sessions/ subfolder in the project root (next to main.py)."""
+    """Per-user sessions/ folder. Falls back to ~/Documents/Splatt2 on error."""
     try:
-        base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        return os.path.join(base, "sessions")
+        from core.paths import sessions_dir
+        return str(sessions_dir())
     except Exception:
         return os.path.join(os.path.expanduser("~"), "Documents", "Splatt2")
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -1372,27 +1372,37 @@ class SplattApp:
     def _open_settings(self):
         SettingsDialog(self.root, self.cfg, self._apply_settings)
 
+    _CAM_RESTART_KEYS = frozenset({
+        "video_width", "video_height", "video_fps",
+        "camera_index", "no_video_mode",
+    })
+    _TRACKER_REBUILD_KEYS = frozenset({
+        "aruco_marker_mm", "aruco_margin_mm", "aruco_dict",
+        "use_clahe", "clahe_clip", "aruco_marker_count",
+        "brightness_target",
+    })
+
     def _apply_settings(self, new_cfg):
-        cam_keys = {"video_width", "video_height", "video_fps",
-                    "camera_index", "no_video_mode"}
-        cam_changed = any(new_cfg.get(k) != self.cfg.get(k) for k in cam_keys)
+        cam_changed = any(new_cfg.get(k) != self.cfg.get(k)
+                          for k in self._CAM_RESTART_KEYS)
+        tracker_changed = any(new_cfg.get(k) != self.cfg.get(k)
+                              for k in self._TRACKER_REBUILD_KEYS)
 
         self.cfg.update(new_cfg)
         save_config(self.cfg)
         self.target_cfg = TARGETS[self.cfg["target_key"]]
         self.target_renderer = None
 
-        # Audio — applies live
+        # Audio settings apply live.
         self.audio.set_threshold(self.cfg["audio_trigger_threshold"])
         self.audio.set_transient_ratio(self.cfg.get("audio_transient_ratio", 6.0))
         self.audio.set_cooldown(self.cfg["audio_trigger_cooldown_ms"])
         self._thresh_var.set(self.cfg["audio_trigger_threshold"])
         self._ratio_var.set(self.cfg.get("audio_transient_ratio", 6.0))
+        self._post_shot_cooldown_s = float(
+            self.cfg.get("post_shot_cooldown_s", 2.0))
 
-        # Cooldown — live
-        self._post_shot_cooldown_s = float(self.cfg.get("post_shot_cooldown_s", 2.0))
-
-        # Smoother — live, no restart needed
+        # Smoother is cheap to rebuild.
         self._smoother = make_smoother(
             self.cfg.get("smooth_mode", "ema"),
             alpha=float(self.cfg.get("smooth_alpha", 0.35)),
@@ -1401,9 +1411,7 @@ class SplattApp:
         )
         self._smoother.reset()
 
-        # Rebuild tracker if marker size changed
-        marker_keys = {"aruco_marker_mm", "aruco_margin_mm", "aruco_dict", "use_clahe", "clahe_clip", "aruco_marker_count", "brightness_target"}
-        if any(new_cfg.get(k) != self.cfg.get(k) for k in marker_keys):
+        if tracker_changed:
             self.tracker = ArucoTracker(
                 aruco_dict_name=self.cfg["aruco_dict"],
                 marker_size_mm=float(self.cfg.get("aruco_marker_mm", 40.0)),
@@ -1411,26 +1419,26 @@ class SplattApp:
                 use_clahe=bool(self.cfg.get("use_clahe", True)),
                 clahe_clip=float(self.cfg.get("clahe_clip", 4.0)),
                 marker_count=int(self.cfg.get("aruco_marker_count", 4)),
-                brightness_target=float(self.cfg.get("brightness_target", 128.0)),
+                brightness_target=float(
+                    self.cfg.get("brightness_target", 128.0)),
             )
 
-        # Rotation — applies immediately to camera loop
         self._camera_rotation = int(self.cfg.get("camera_rotation", 0))
-        self._fine_zero_mode = False   # click-on-canvas zero fine-tune
+        self._fine_zero_mode = False
         if hasattr(self, "_btn_rotate"):
             rot = self._camera_rotation
-            self._btn_rotate.config(text=f"↻ {rot}°",
+            self._btn_rotate.config(
+                text=f"↻ {rot}°",
                 bg=BG_CARD if rot == 0 else ACCENT,
-                fg=TEXT_SEC if rot == 0 else BG_DARK)
+                fg=TEXT_SEC if rot == 0 else BG_DARK,
+            )
 
-        # Sync zero offset from config (reset via Settings takes effect now)
         self._zero_offset = (
             float(self.cfg.get("zero_offset_x", 0.0)),
             float(self.cfg.get("zero_offset_y", 0.0)),
         )
-        self._apply_session_cfg()  # push new cfg values into live session
+        self._apply_session_cfg()
 
-        # Camera resolution/fps — restart to take effect
         if cam_changed and self._running:
             self._set_status("Restarting camera with new settings…", GOLD)
             self._stop_camera()

--- a/ui/app.py
+++ b/ui/app.py
@@ -1706,13 +1706,19 @@ class SplattApp:
     def _editor_select_all(self, value: bool):
         for var in self._editor_shot_vars.values():
             var.set(value)
+    _KEY_BINDINGS = {
+        "p": "_toggle_pause",
+        "space": "_undo_shot",
+        "r": "_reset_all",
+        "q": "_on_close",
+        "s": "_save_csv",
+    }
+
     def _on_key(self, event):
-        k = event.keysym.lower()
-        if k == "p":         self._toggle_pause()
-        elif k == "space":   self._undo_shot()
-        elif k == "r":       self._reset_all()
-        elif k == "q":       self._on_close()
-        elif k == "s":       self._save_csv()
+        action = self._KEY_BINDINGS.get(event.keysym.lower())
+        if action:
+            getattr(self, action)()
+
     def _on_close(self):
         self._running = False
         self.audio.stop()

--- a/ui/app.py
+++ b/ui/app.py
@@ -1233,30 +1233,32 @@ class SplattApp:
                                     bg=BG_CARD if self._camera_rotation == 0 else ACCENT,
                                     fg=TEXT_SEC if self._camera_rotation == 0 else BG_DARK)
 
+    def _set_toggle_button(self, button: tk.Button, active: bool) -> None:
+        """Apply the standard accent/idle styling to a toggle button."""
+        button.config(
+            bg=ACCENT if active else BG_CARD,
+            fg=BG_DARK if active else TEXT_SEC,
+        )
+
     def _toggle_acp(self):
         self._show_acp = not self._show_acp
-        self._btn_acp.config(bg=ACCENT if self._show_acp else BG_CARD,
-                              fg=BG_DARK if self._show_acp else TEXT_SEC)
+        self._set_toggle_button(self._btn_acp, self._show_acp)
 
     def _toggle_bbox_shots(self):
         self._show_bbox_shots = not self._show_bbox_shots
-        self._btn_bbox_s.config(bg=ACCENT if self._show_bbox_shots else BG_CARD,
-                                 fg=BG_DARK if self._show_bbox_shots else TEXT_SEC)
+        self._set_toggle_button(self._btn_bbox_s, self._show_bbox_shots)
 
     def _toggle_bbox_acp(self):
         self._show_bbox_acp = not self._show_bbox_acp
-        self._btn_bbox_a.config(bg=ACCENT if self._show_bbox_acp else BG_CARD,
-                                 fg=BG_DARK if self._show_bbox_acp else TEXT_SEC)
+        self._set_toggle_button(self._btn_bbox_a, self._show_bbox_acp)
 
     def _toggle_dot_mode(self):
         self._shot_dot_only = not self._shot_dot_only
-        self._btn_dot.config(bg=ACCENT if self._shot_dot_only else BG_CARD,
-                              fg=BG_DARK if self._shot_dot_only else TEXT_SEC)
+        self._set_toggle_button(self._btn_dot, self._shot_dot_only)
 
     def _toggle_group(self):
         self._show_group = not self._show_group
-        self._btn_group.config(bg=ACCENT if self._show_group else BG_CARD,
-                                fg=BG_DARK if self._show_group else TEXT_SEC)
+        self._set_toggle_button(self._btn_group, self._show_group)
 
     def _undo_shot(self):
         shot = self.session.undo_last_shot()

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -1,0 +1,56 @@
+"""Visual theme: palette, fonts and a button factory.
+
+Centralising these lets dialogs and the main window share a consistent
+look without duplicating colour values.
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from typing import Callable, Optional
+
+# Background tones, dark to light.
+BG_DARK = "#0f0f13"
+BG_MID = "#16161d"
+BG_PANEL = "#1c1c25"
+BG_CARD = "#22222e"
+
+# Foreground accents and text.
+ACCENT = "#00e5a0"
+ACCENT2 = "#ff4f6d"
+TEXT_PRI = "#f0f0f8"
+TEXT_SEC = "#c0c0d8"
+TEXT_DIM = "#9090b0"
+BORDER = "#2a2a3a"
+GOLD = "#ffd060"
+
+# Fonts. Values match the existing UI; rename only inside the UI package.
+FM = ("Consolas", 10)
+FT = ("Segoe UI", 9, "bold")
+FS = ("Consolas", 42, "bold")
+FL = ("Segoe UI", 9)
+FB = ("Segoe UI", 10)
+FH = ("Segoe UI", 11)
+
+
+def make_button(
+    parent: tk.Misc,
+    text: str,
+    command: Callable[[], None],
+    accent: bool = False,
+    width: Optional[int] = None,
+) -> tk.Button:
+    """Themed flat button used throughout the UI."""
+    fg = BG_DARK if accent else TEXT_SEC
+    bg = ACCENT if accent else BG_CARD
+    kwargs = dict(
+        bg=bg, fg=fg,
+        activebackground=ACCENT if accent else BORDER,
+        activeforeground=fg,
+        font=FB, relief="flat", bd=0,
+        padx=8, pady=5, cursor="hand2",
+        text=text, command=command,
+    )
+    if width:
+        kwargs["width"] = width
+    return tk.Button(parent, **kwargs)

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -1,12 +1,14 @@
-"""Visual theme: palette, fonts and a button factory.
+"""Visual theme: palette, fonts, button factories and ttk styling.
 
-Centralising these lets dialogs and the main window share a consistent
-look without duplicating colour values.
+Tk on macOS uses a native button renderer that ignores ``bg``/``fg``,
+so all interactive widgets in this app are ``ttk`` instances driven by
+the named styles configured in :func:`apply_theme`.
 """
 
 from __future__ import annotations
 
 import tkinter as tk
+import tkinter.ttk as ttk
 from typing import Callable, Optional
 
 # Background tones, dark to light.
@@ -18,39 +20,401 @@ BG_CARD = "#22222e"
 # Foreground accents and text.
 ACCENT = "#00e5a0"
 ACCENT2 = "#ff4f6d"
+BLUE = "#4f8fff"
 TEXT_PRI = "#f0f0f8"
 TEXT_SEC = "#c0c0d8"
 TEXT_DIM = "#9090b0"
 BORDER = "#2a2a3a"
 GOLD = "#ffd060"
 
-# Fonts. Values match the existing UI; rename only inside the UI package.
+# Fonts.
 FM = ("Consolas", 10)
 FT = ("Segoe UI", 9, "bold")
 FS = ("Consolas", 42, "bold")
 FL = ("Segoe UI", 9)
 FB = ("Segoe UI", 10)
 FH = ("Segoe UI", 11)
+FL_BOLD = ("Segoe UI", 9, "bold")
+
+
+# Style names. Toggle-on styles are created lazily per accent colour
+# so a single shared idle style covers the off state.
+_STYLE_DEFAULT = "Splatt.TButton"
+_STYLE_ACCENT = "Splatt.Accent.TButton"
+_STYLE_DANGER = "Splatt.Danger.TButton"
+_STYLE_CHIP = "Splatt.Chip.TButton"
+_STYLE_TOGGLE_OFF = "Splatt.Toggle.Off.TButton"
+
+_VARIANT_STYLES = {
+    "default": _STYLE_DEFAULT,
+    "accent": _STYLE_ACCENT,
+    "danger": _STYLE_DANGER,
+    "chip": _STYLE_CHIP,
+    "toggle_off": _STYLE_TOGGLE_OFF,
+}
+
+# Maps an accent colour to its lazily-created toggle-on style name.
+_TOGGLE_ON_STYLES: dict[str, str] = {}
+
+
+def _toggle_on_style_name(accent_color: str) -> str:
+    return f"Splatt.Toggle.On.{accent_color.lstrip('#')}.TButton"
 
 
 def make_button(
     parent: tk.Misc,
     text: str,
     command: Callable[[], None],
+    *,
     accent: bool = False,
+    danger: bool = False,
     width: Optional[int] = None,
-) -> tk.Button:
-    """Themed flat button used throughout the UI."""
-    fg = BG_DARK if accent else TEXT_SEC
-    bg = ACCENT if accent else BG_CARD
-    kwargs = dict(
-        bg=bg, fg=fg,
-        activebackground=ACCENT if accent else BORDER,
-        activeforeground=fg,
-        font=FB, relief="flat", bd=0,
-        padx=8, pady=5, cursor="hand2",
-        text=text, command=command,
-    )
-    if width:
+) -> ttk.Button:
+    """Themed flat button.
+
+    ``accent`` picks the primary action style, ``danger`` the destructive
+    one. Without either, the neutral default style is used.
+    """
+    if danger:
+        style = _STYLE_DANGER
+    elif accent:
+        style = _STYLE_ACCENT
+    else:
+        style = _STYLE_DEFAULT
+    kwargs: dict = {"text": text, "command": command, "style": style,
+                    "cursor": "hand2"}
+    if width is not None:
         kwargs["width"] = width
-    return tk.Button(parent, **kwargs)
+    return ttk.Button(parent, **kwargs)
+
+
+def make_toggle_button(
+    parent: tk.Misc,
+    text: str,
+    state: bool,
+    command: Callable[[], None],
+    *,
+    accent_color: str = ACCENT,
+) -> ttk.Button:
+    """Themed two-state toggle button.
+
+    The active state fills with ``accent_color`` and uses bold text;
+    the inactive state shares the chip-like idle look.
+    """
+    btn = ttk.Button(parent, text=text, command=command, cursor="hand2")
+    set_toggle_state(btn, state, accent_color=accent_color)
+    return btn
+
+
+def make_chip_button(
+    parent: tk.Misc,
+    text: str,
+    command: Callable[[], None],
+) -> ttk.Button:
+    """Compact preset/value button used inline in dialog rows."""
+    return ttk.Button(parent, text=text, command=command,
+                      style=_STYLE_CHIP, cursor="hand2")
+
+
+def set_button_variant(button: ttk.Button, variant: str) -> None:
+    """Switch a button between visual variants at runtime.
+
+    ``variant`` is one of ``default``, ``accent``, ``danger``, ``chip``
+    or ``toggle_off``. Unknown names fall back to ``default``.
+    """
+    button.configure(style=_VARIANT_STYLES.get(variant, _STYLE_DEFAULT))
+
+
+def set_toggle_state(
+    button: ttk.Button,
+    active: bool,
+    *,
+    accent_color: str = ACCENT,
+) -> None:
+    """Toggle a button between its on (filled) and off (idle) styling."""
+    if active:
+        _ensure_toggle_on_style(accent_color)
+        button.configure(style=_TOGGLE_ON_STYLES[accent_color])
+    else:
+        button.configure(style=_STYLE_TOGGLE_OFF)
+
+
+def _ensure_toggle_on_style(accent_color: str) -> None:
+    if accent_color in _TOGGLE_ON_STYLES:
+        return
+    name = _toggle_on_style_name(accent_color)
+    s = ttk.Style()
+    s.configure(
+        name,
+        background=accent_color, foreground=BG_DARK,
+        bordercolor=accent_color,
+        lightcolor=accent_color, darkcolor=accent_color,
+        focuscolor=accent_color,
+        font=FL_BOLD, padding=(8, 3), relief="flat", borderwidth=0,
+    )
+    s.map(
+        name,
+        background=[("active", accent_color), ("pressed", accent_color)],
+        foreground=[("active", BG_DARK), ("pressed", BG_DARK)],
+        bordercolor=[("active", accent_color)],
+    )
+    _TOGGLE_ON_STYLES[accent_color] = name
+
+
+def apply_theme(root: tk.Misc) -> None:
+    """Install the dark palette on ``root`` and all its toplevels.
+
+    Must run before any widgets are created so option-database entries
+    apply to plain ``tk`` widgets in dialogs. ttk style settings are
+    global to the interpreter and propagate to every toplevel.
+    """
+    style = ttk.Style(root)
+    # ``clam`` is the only built-in theme that honours custom colours
+    # reliably across platforms; the macOS ``aqua`` theme overrides
+    # backgrounds for buttons and entries.
+    style.theme_use("clam")
+
+    _configure_buttons(style)
+    _configure_inputs(style)
+    _configure_containers(style)
+    _configure_indicators(style)
+    _install_option_db(root)
+
+
+def _configure_buttons(style: ttk.Style) -> None:
+    style.configure(
+        _STYLE_DEFAULT,
+        background=BG_CARD, foreground=TEXT_PRI,
+        bordercolor=BORDER, lightcolor=BORDER, darkcolor=BORDER,
+        focuscolor=BG_CARD,
+        font=FB, padding=(10, 6), relief="flat", borderwidth=0,
+    )
+    style.map(
+        _STYLE_DEFAULT,
+        background=[("active", BG_MID), ("pressed", BORDER),
+                    ("disabled", BG_PANEL)],
+        foreground=[("active", TEXT_PRI), ("pressed", ACCENT),
+                    ("disabled", TEXT_DIM)],
+        bordercolor=[("focus", ACCENT), ("active", BORDER)],
+    )
+
+    style.configure(
+        _STYLE_ACCENT,
+        background=ACCENT, foreground=BG_DARK,
+        bordercolor=ACCENT, lightcolor=ACCENT, darkcolor=ACCENT,
+        focuscolor=ACCENT,
+        font=FB, padding=(10, 6), relief="flat", borderwidth=0,
+    )
+    style.map(
+        _STYLE_ACCENT,
+        background=[("active", ACCENT), ("pressed", "#00b87f"),
+                    ("disabled", BG_PANEL)],
+        foreground=[("active", BG_DARK), ("pressed", BG_DARK),
+                    ("disabled", TEXT_DIM)],
+        bordercolor=[("focus", ACCENT)],
+    )
+
+    style.configure(
+        _STYLE_DANGER,
+        background=ACCENT2, foreground=BG_DARK,
+        bordercolor=ACCENT2, lightcolor=ACCENT2, darkcolor=ACCENT2,
+        focuscolor=ACCENT2,
+        font=FB, padding=(10, 6), relief="flat", borderwidth=0,
+    )
+    style.map(
+        _STYLE_DANGER,
+        background=[("active", ACCENT2), ("pressed", "#cc3a55")],
+        foreground=[("active", BG_DARK), ("pressed", BG_DARK)],
+    )
+
+    chip_config = dict(
+        background=BG_CARD, foreground=TEXT_DIM,
+        bordercolor=BORDER, lightcolor=BORDER, darkcolor=BORDER,
+        focuscolor=BG_CARD,
+        font=FL, padding=(8, 3), relief="flat", borderwidth=0,
+    )
+    chip_map = dict(
+        background=[("active", BG_MID), ("pressed", BORDER)],
+        foreground=[("active", TEXT_PRI), ("pressed", ACCENT)],
+        bordercolor=[("active", ACCENT), ("focus", ACCENT)],
+    )
+    for name in (_STYLE_CHIP, _STYLE_TOGGLE_OFF):
+        style.configure(name, **chip_config)
+        style.map(name, **chip_map)
+
+    for accent in (ACCENT, GOLD, BLUE, ACCENT2):
+        _ensure_toggle_on_style(accent)
+
+
+def _configure_inputs(style: ttk.Style) -> None:
+    style.configure(
+        "TCombobox",
+        fieldbackground=BG_CARD, background=BG_CARD,
+        foreground=TEXT_PRI, arrowcolor=ACCENT,
+        bordercolor=BORDER, lightcolor=BORDER, darkcolor=BORDER,
+        selectbackground=BG_CARD, selectforeground=TEXT_PRI,
+        insertcolor=ACCENT, padding=4,
+    )
+    style.map(
+        "TCombobox",
+        fieldbackground=[("readonly", BG_CARD), ("disabled", BG_PANEL)],
+        foreground=[("disabled", TEXT_DIM)],
+        background=[("active", BG_MID), ("readonly", BG_CARD)],
+        bordercolor=[("focus", ACCENT), ("hover", ACCENT)],
+        arrowcolor=[("hover", TEXT_PRI)],
+    )
+
+    for name in ("TEntry", "TSpinbox"):
+        style.configure(
+            name,
+            fieldbackground=BG_CARD, background=BG_CARD,
+            foreground=TEXT_PRI,
+            bordercolor=BORDER, lightcolor=BORDER, darkcolor=BORDER,
+            insertcolor=ACCENT,
+            selectbackground=ACCENT, selectforeground=BG_DARK,
+            padding=4,
+        )
+        style.map(
+            name,
+            fieldbackground=[("disabled", BG_PANEL)],
+            foreground=[("disabled", TEXT_DIM)],
+            bordercolor=[("focus", ACCENT)],
+        )
+
+    for name in ("TScale", "Horizontal.TScale"):
+        style.configure(
+            name,
+            background=BG_MID, troughcolor=BG_CARD,
+            bordercolor=BG_MID, lightcolor=BG_MID, darkcolor=BG_MID,
+        )
+
+
+def _configure_containers(style: ttk.Style) -> None:
+    style.configure("TFrame", background=BG_DARK)
+    style.configure("TLabel", background=BG_DARK, foreground=TEXT_SEC)
+    style.configure(
+        "TLabelframe",
+        background=BG_DARK, foreground=TEXT_DIM,
+        bordercolor=BORDER, lightcolor=BORDER, darkcolor=BORDER,
+    )
+    style.configure(
+        "TLabelframe.Label",
+        background=BG_DARK, foreground=TEXT_DIM,
+    )
+
+    style.configure("TNotebook", background=BG_DARK, borderwidth=0)
+    style.configure(
+        "TNotebook.Tab",
+        background=BG_CARD, foreground=TEXT_SEC,
+        padding=[10, 4], borderwidth=0,
+    )
+    style.map(
+        "TNotebook.Tab",
+        background=[("selected", BG_PANEL), ("active", BG_MID)],
+        foreground=[("selected", ACCENT), ("active", TEXT_PRI)],
+    )
+
+    for name in ("Vertical.TScrollbar", "Horizontal.TScrollbar"):
+        style.configure(
+            name,
+            background=BG_CARD, troughcolor=BG_DARK,
+            bordercolor=BG_DARK, arrowcolor=TEXT_DIM,
+            gripcount=0, relief="flat",
+            lightcolor=BG_CARD, darkcolor=BG_CARD,
+        )
+        style.map(
+            name,
+            background=[("active", BG_MID), ("pressed", BORDER)],
+            arrowcolor=[("active", ACCENT), ("pressed", ACCENT)],
+        )
+
+
+def _configure_indicators(style: ttk.Style) -> None:
+    for name, col in (("Quality", ACCENT), ("Audio", BLUE)):
+        style.configure(
+            f"{name}.Horizontal.TProgressbar",
+            troughcolor=BG_DARK, background=col,
+            bordercolor=BG_DARK, lightcolor=col, darkcolor=col,
+        )
+
+    style.configure(
+        "TCheckbutton",
+        background=BG_DARK, foreground=TEXT_SEC,
+        focuscolor=BG_DARK,
+        indicatorcolor=BG_CARD, indicatorbackground=BG_CARD,
+        bordercolor=BORDER,
+    )
+    style.map(
+        "TCheckbutton",
+        background=[("active", BG_DARK)],
+        foreground=[("disabled", TEXT_DIM), ("active", TEXT_PRI)],
+        indicatorcolor=[("selected", ACCENT), ("pressed", ACCENT)],
+    )
+
+    style.configure(
+        "TRadiobutton",
+        background=BG_DARK, foreground=TEXT_SEC,
+        focuscolor=BG_DARK,
+        indicatorcolor=BG_CARD, bordercolor=BORDER,
+    )
+    style.map(
+        "TRadiobutton",
+        background=[("active", BG_DARK)],
+        foreground=[("disabled", TEXT_DIM), ("active", TEXT_PRI)],
+        indicatorcolor=[("selected", ACCENT)],
+    )
+
+
+def _install_option_db(root: tk.Misc) -> None:
+    """Theme plain ``tk`` widgets that don't go through ``ttk.Style``."""
+    options = {
+        "*TCombobox*Listbox.background": BG_CARD,
+        "*TCombobox*Listbox.foreground": TEXT_PRI,
+        "*TCombobox*Listbox.selectBackground": ACCENT,
+        "*TCombobox*Listbox.selectForeground": BG_DARK,
+        "*TCombobox*Listbox.borderWidth": 0,
+        "*TCombobox*Listbox.relief": "flat",
+        "*TCombobox*Listbox.font": FM,
+
+        "*Listbox.background": BG_CARD,
+        "*Listbox.foreground": TEXT_PRI,
+        "*Listbox.selectBackground": ACCENT,
+        "*Listbox.selectForeground": BG_DARK,
+        "*Listbox.borderWidth": 0,
+        "*Listbox.highlightThickness": 0,
+
+        "*Entry.background": BG_CARD,
+        "*Entry.foreground": TEXT_PRI,
+        "*Entry.insertBackground": ACCENT,
+        "*Entry.selectBackground": ACCENT,
+        "*Entry.selectForeground": BG_DARK,
+        "*Entry.relief": "flat",
+        "*Entry.borderWidth": 0,
+        "*Entry.highlightThickness": 1,
+        "*Entry.highlightBackground": BORDER,
+        "*Entry.highlightColor": ACCENT,
+
+        "*Checkbutton.background": BG_DARK,
+        "*Checkbutton.foreground": TEXT_SEC,
+        "*Checkbutton.activeBackground": BG_DARK,
+        "*Checkbutton.activeForeground": TEXT_PRI,
+        "*Checkbutton.selectColor": BG_CARD,
+        "*Checkbutton.borderWidth": 0,
+        "*Checkbutton.highlightThickness": 0,
+
+        "*Menu.background": BG_PANEL,
+        "*Menu.foreground": TEXT_PRI,
+        "*Menu.activeBackground": ACCENT,
+        "*Menu.activeForeground": BG_DARK,
+        "*Menu.borderWidth": 0,
+        "*Menu.relief": "flat",
+
+        "*Scrollbar.background": BG_CARD,
+        "*Scrollbar.troughColor": BG_DARK,
+        "*Scrollbar.activeBackground": BG_MID,
+        "*Scrollbar.borderWidth": 0,
+        "*Scrollbar.elementBorderWidth": 0,
+        "*Scrollbar.highlightThickness": 0,
+    }
+    for pattern, value in options.items():
+        root.option_add(pattern, value)


### PR DESCRIPTION
Branched off https://github.com/Nonkeydonk/splatt2/pull/4 so that must be merged first

Embed DPI metadata in the printed marker sheet PNG.

The marker sheet generator already renders at 2480x3508, which is exactly A4 at 300 DPI. The problem was that cv2.imwrite writes a bare PNG with no DPI metadata.

When the file gets opened in Preview, Acrobat, or a system print window, the print pipeline guesses the DPI itself, usually 72 or 96. That makes the page appear far larger than A4 unless the user manually enables "fit to page", which then scales the markers and throws calibration off.

Fix is replacing cv2.imwrite with a small _save_with_dpi helper that round-trips through Pillow and saves with dpi=(300, 300).

Pillow writes the normal PNG pHYs metadata chunk and JPEG density fields, so common print pipelines now open the sheet at the correct physical size automatically.